### PR TITLE
Adds bundle for k8s cronjobs

### DIFF
--- a/core/mondoo-kubernetes-incident-response.mql.yaml
+++ b/core/mondoo-kubernetes-incident-response.mql.yaml
@@ -63,6 +63,12 @@ packs:
             }
             podSpec["nodeName"]
           }
+  - uid: mondoo-kubernetes-cronjobs-incident-response
+    name: Mondoo Kubernetes CronJobs Incident Response
+    is_public: true
+    filters:
+      - asset.platform == "k8s-cronjob"
+    queries:
       - uid: k8s-cronjobs
         title: Gather CronJobs
         query: |


### PR DESCRIPTION
This PR creates a new bundle for `k8s.cronjob`. Previous query was under the wrong asset filter. 

Signed-off-by: Scott Ford <scott@scottford.io>