### PR TITLE
🧹 align openssl pack file name to query pack name

### DIFF
--- a/core/mondoo-openssl-incident-response.mql.yaml
+++ b/core/mondoo-openssl-incident-response.mql.yaml
@@ -3,7 +3,7 @@ packs:
     name: Mondoo OpenSSL Incident Response
     is_public: true
     filters:
-      - asset.family.contains("unix")
+      - asset.family.contains("linux")
     queries:
       - uid: mondoo-openssl-platform
         title: Retreive information about the Platform


### PR DESCRIPTION
- restrict openssl incident response to linux
- align filename to policy name