### PR TITLE
⭐️ slack incident response pack

### DIFF
--- a/extra/mondoo-slack-incident-response.mql.yaml
+++ b/extra/mondoo-slack-incident-response.mql.yaml
@@ -1,0 +1,70 @@
+packs:
+  - uid: mondoo-slack-incident-response
+    name: Mondoo Slack Incident Response
+    is_public: true
+    docs:
+      desc: |
+        ### Overview
+
+        The Mondoo Slack Security policy ensures best-practice settings for Slack workspaces.
+
+        ### Prerequisites
+
+        To run this query pack, you will need access to the Slack API. To get a token, you need to create an App for the Slack workspace 
+        and assign the appropriate permissions:
+
+        1. Sign in to [the Slack website](https://api.slack.com/apps/), and view "Your Apps"
+        2. Click "Create New App"
+        3. Select "From scratch"
+        4. Enter an "App Name" e.g. cnquery and select the workspace, then click "Create App"
+        5. In the section "Add features & functionality" click on "Permissions"
+        6. Scroll to "Scopes" and then "User Token Scopes"
+ 
+        Note: Bots are very limited in their access; therefore we need to set the user scopes
+
+        7. Add the required permissions to "User Token Scopes"
+
+        | OAuth Scope  |
+        | ---- | 
+        | [channels:read](https://api.slack.com/scopes/channels:read) | 
+        | [groups:read](https://api.slack.com/scopes/groups:read) |
+        | [im:read](https://api.slack.com/scopes/im:read) |
+        | [mpim:read](https://api.slack.com/scopes/mpim:read) | 
+        | [team:read](https://api.slack.com/scopes/team:read) | 
+        | [usergroups:read](https://api.slack.com/scopes/usergroups:read) | 
+        | [users:read](https://api.slack.com/scopes/users:read) |
+
+        8. Scroll up to "OAuth Tokens for Your Workspace" and click "Install to Workspace"
+        9. Copy the provided "User OAuth Token", it will look like `xoxp-1234567890123-1234567890123-1234567890123-12345cea5ae0d3bed30dca43cb34c2d1`
+
+        ### Run query pack
+
+        To run this query pack against a Slack worksapce:
+
+        ```bash
+        export SLACK_TOKEN=xoxp-TOKEN
+        cnquery scan slack --query-pack mondoo-incident-response-slack
+        ```
+    filters:
+      - asset.platform == "slack"
+    queries:
+      - uid: mondoo-slack-incident-response-team-domain
+        title: Retrieve Slack Team Domain
+        query: |
+          slack.team.domain
+      - uid: mondoo-slack-incident-response-team-id
+        title: Retrieve Slack Team ID
+        query: |
+          slack.team.id
+      - uid: mondoo-slack-incident-response-mfa-status
+        title: Retrieve Slack Team MFA status 
+        docs:
+          desc: |
+            This query retrieves the status of whether MFA is configured for all users. 
+        query: |
+          slack.users { id name profile["email"] isBot teamId has2FA }
+      - uid: mondoo-slack-incident-response-owners
+        title: Retrieve Slack Team Owners
+        query: |
+          slack.users.owners.length
+          slack.users.owners { id name profile["email"] isBot teamId has2FA }


### PR DESCRIPTION
```
cnquery scan slack -f extra/mondoo-slack-incident-response.mql.yaml
! Scanning with local bundles will switch into --incognito mode by default. Your results will not be sent upstream.
→ discover related assets for 1 asset(s)
→ resolved assets resolved-assets=1
→ connecting to asset Slack organization test labs (api)
Asset: Slack organization test labs
========================

Retrieve GitHub Organization Owners:
slack.users.owners.length: 1
slack.users.owners: [
  0: {
    isBot: false
    profile[email]: ""
    id: "UEABCDEFG"
    name: "chris"
    has2FA: false
    teamId: "TEABCDEFG"
  }
... 1 more lines ...

Retrieve Slack Team Domain:
slack.team.domain: "testlabs"

Retrieve Slack Team ID:
slack.team.id: "TEABCDEFG"

Retrieve Slack Team MFA status:
slack.users.list: [
  0: {
    name: "slackbot"
    isBot: false
    profile[email]: ""
    has2FA: false
    teamId: "TEABCDEFG"
    id: "USLACKBOT"
  }
  1: {
... 40 more lines ...



Summary (1 assets)
========================
Target:     Slack organization test labs
Datapoints: 5
```