### PR TITLE
⭐️ okta incident response pack

### DIFF
--- a/extra/mondoo-okta-incident-response.mql.yaml
+++ b/extra/mondoo-okta-incident-response.mql.yaml
@@ -1,0 +1,34 @@
+packs:
+  - uid: mondoo-okta-incident-response
+    name: Mondoo Okta Incident Response
+    is_public: true
+    docs:
+      desc: |
+        ### Overview
+
+        The Mondoo Okta Incident Response Pack query pack gathers configuration data about your Okta investigation during a security incident.
+
+        ### Prerequisites
+
+        To run this query pack, you will need access to the Okta API:
+
+        1. Create an Okta [API token](https://developer.okta.com/docs/guides/create-an-api-token/create-the-token/) by going to https:/DOMAIN.okta.com/admin/access/api/tokens
+        2. Note your Okta domain https://DOMAIN.okta.com
+
+        ### Run query pack
+
+        To run this query pack against a Okta domain:
+
+        ```bash
+        export OKTA_TOKEN=<TOKEN>
+        cnquery shell okta --organization DOMAIN.okta.com --token $OKTA_TOKEN 
+        ```
+    filters:
+      - asset.platform == "okta"
+    queries:
+      - uid: mondoo-slack-incident-response-users
+        title: Retrieve Users
+        query: okta.users { * }
+      - uid: mondoo-slack-incident-response-team-id
+        title: Retrieve installed applications
+        query: okta.applications  { * }

--- a/extra/mondoo-slack-incident-response.mql.yaml
+++ b/extra/mondoo-slack-incident-response.mql.yaml
@@ -6,7 +6,7 @@ packs:
       desc: |
         ### Overview
 
-        The Mondoo Slack Security policy ensures best-practice settings for Slack workspaces.
+        The Mondoo Slack Incident Response Pack query pack gathers configuration data about your Slack investigation during a security incident.
 
         ### Prerequisites
 


### PR DESCRIPTION
```
cnquery scan okta --organization dev-1234567.okta.com --token $OKTA_TOKEN -f extra/mondoo-okta-incident-response.mql.yaml
→ discover related assets for 1 asset(s)
→ credentials credentials=1
→ resolved assets resolved-assets=1
→ connecting to asset Okta organization dev-1234567.okta.com (api)
→ credentials credentials=1
Asset: Okta organization dev-70431530.okta.com
===================================  100% Okta organization dev-1234567.okta.com

Retrieve Users:
okta.users: [
  0: {
    id: "00a00abcdefgABa12345b7"
    activated: null
    passwordChanged: 2022-11-02 02:16:41 +0100 CET
    status: "RECOVERY"
    profile: null
    lastLogin: 2022-11-15 21:45:01 +0100 CET
    created: 2022-11-01 19:30:37 +0100 CET
    type: {
... 14 more lines ...

Retrieve installed applications:
okta.applications: [
  0: {
    features: []
    status: "ACTIVE"
    name: "saasure"
    credentials: {
      signing: {
        kid: "AaA1AaAaaaaA1AAA1AAAaAA1Aa11aAaAaaaa111aaa1"
      }
      userNameTemplate: {
... 109 more lines ...



Summary (1 assets)
========================
Target:     Okta organization dev-70431530.okta.com
Datapoints: 2

```