### PR TITLE
🧹 update saas asset names to latest improvement

### DIFF
--- a/extra/mondoo-googleworkplace-incident-response.mql.yaml
+++ b/extra/mondoo-googleworkplace-incident-response.mql.yaml
@@ -49,7 +49,7 @@ packs:
         cnquery scan googleworkspace --customer-id <CUSTOMERID> --impersonated-user-email <EMAIL>
         ```
     filters:
-      - asset.platform == "googleworkspace"
+      - asset.platform == "googleworkspace" || asset.platform == "google-workspace"
     queries:
       - uid: mondoo-googleworkspace-incident-response-domain
         title: Retrieve Google Workspace Domains

--- a/extra/mondoo-slack-incident-response.mql.yaml
+++ b/extra/mondoo-slack-incident-response.mql.yaml
@@ -45,7 +45,7 @@ packs:
         cnquery scan slack --query-pack mondoo-incident-response-slack
         ```
     filters:
-      - asset.platform == "slack"
+      - asset.platform == "slack" || asset.platform == "slack-team"
     queries:
       - uid: mondoo-slack-incident-response-team-domain
         title: Retrieve Slack Team Domain


### PR DESCRIPTION
aligns the packs to the new asset filters required for slack and google workspace. See similar PR https://github.com/mondoohq/cnspec-policies/pull/120