### PR TITLE
Use consistent naming for packs

### DIFF
--- a/core/mondoo-github-inventory.mql.yaml
+++ b/core/mondoo-github-inventory.mql.yaml
@@ -66,7 +66,7 @@ packs:
         title: GitHub organization updated
         query: github.organization.updatedAt
   - uid: mondoo-github-inventory-user
-    name: Mondoo GitHub User Inventory Pack
+    name: GitHub User Inventory Pack by Mondoo
     version: 1.0.0
     tags:
       mondoo.com/platform: github,saas
@@ -132,7 +132,7 @@ packs:
         title: GitHub user updated
         query: github.user.updatedAt
   - uid: mondoo-github-inventory-repo
-    name: Mondoo GitHub Repository Inventory Pack
+    name: GitHub Repository Inventory Pack by Mondoo
     version: 1.0.0
     tags:
       mondoo.com/platform: github,saas

--- a/core/mondoo-kubernetes-incident-response.mql.yaml
+++ b/core/mondoo-kubernetes-incident-response.mql.yaml
@@ -30,7 +30,7 @@ packs:
             roleRef
           }
   - uid: mondoo-kubernetes-pods-incident-response
-    name: Mondoo Kubernetes Pods Incident Response
+    name: Kubernetes Pods Incident Response Pack by Mondoo
     version: 1.0.0
     tags:
       mondoo.com/platform: kubernetes,k8s # remove k8s when v9 is released
@@ -100,7 +100,7 @@ packs:
             podSpec["nodeName"]
           }
   - uid: mondoo-kubernetes-cronjobs-incident-response
-    name: Mondoo Kubernetes CronJobs Incident Response
+    name: Kubernetes CronJobs Incident Response Pack by Mondoo
     version: 1.0.0
     tags:
       mondoo.com/platform: kubernetes,k8s # remove k8s when v9 is released

--- a/core/mondoo-kubernetes-inventory.mql.yaml
+++ b/core/mondoo-kubernetes-inventory.mql.yaml
@@ -39,7 +39,7 @@ packs:
         query: |
           k8s.clusterroles { * }      
   - uid: mondoo-kubernetes-pods-inventory
-    name: Mondoo Kubernetes Pods Inventory
+    name: Kubernetes Pods Inventory Pack by Mondoo
     version: 1.1.0
     tags:
       mondoo.com/platform: kubernetes,k8s # remove k8s when v9 is released
@@ -56,7 +56,7 @@ packs:
         query: |
           k8s.pod.containers { * }
   - uid: mondoo-kubernetes-deployments-inventory
-    name: Mondoo Kubernetes Deployments Inventory
+    name: Kubernetes Deployments Inventory Pack by Mondoo
     version: 1.1.0
     tags:
       mondoo.com/platform: kubernetes,k8s # remove k8s when v9 is released
@@ -73,7 +73,7 @@ packs:
         query: |
           k8s.deployment.containers { * }
   - uid: mondoo-kubernetes-cronjobs-inventory
-    name: Mondoo Kubernetes CronJobs Inventory
+    name: Kubernetes CronJobs Inventory Pack by Mondoo
     version: 1.1.0
     tags:
       mondoo.com/platform: kubernetes,k8s # remove k8s when v9 is released
@@ -90,7 +90,7 @@ packs:
         query: |
           k8s.cronjob.containers { * }
   - uid: mondoo-kubernetes-jobs-inventory
-    name: Mondoo Kubernetes Jobs Inventory
+    name: Kubernetes Jobs Inventory Pack by Mondoo
     version: 1.1.0
     tags:
       mondoo.com/platform: kubernetes,k8s # remove k8s when v9 is released
@@ -107,7 +107,7 @@ packs:
         query: |
           k8s.job.containers { * }
   - uid: mondoo-kubernetes-daemonsets-inventory
-    name: Mondoo Kubernetes DaemonSets Inventory
+    name: Kubernetes DaemonSets Inventory Pack by Mondoo
     version: 1.1.0
     tags:
       mondoo.com/platform: kubernetes,k8s # remove k8s when v9 is released
@@ -124,7 +124,7 @@ packs:
         query: |
           k8s.daemonset.containers { * }
   - uid: mondoo-kubernetes-statefulsets-inventory
-    name: Mondoo Kubernetes StatefulSets Inventory
+    name: Kubernetes StatefulSets Inventory Pack by Mondoo
     version: 1.1.0
     tags:
       mondoo.com/platform: kubernetes,k8s # remove k8s when v9 is released
@@ -141,7 +141,7 @@ packs:
         query: |
           k8s.statefulset.containers { * }
   - uid: mondoo-kubernetes-replicasets-inventory
-    name: Mondoo Kubernetes ReplicaSets Inventory
+    name: Kubernetes ReplicaSets Inventory Pack by Mondoo
     version: 1.1.0
     tags:
       mondoo.com/platform: kubernetes,k8s # remove k8s when v9 is released

--- a/core/mondoo-linux-incident-response.mql.yaml
+++ b/core/mondoo-linux-incident-response.mql.yaml
@@ -1,6 +1,6 @@
 packs:
   - uid: mondoo-linux-incident-response
-    name: Linux Incident Response by Mondoo
+    name: Linux Incident Response Pack by Mondoo
     version: 1.0.0
     tags:
       mondoo.com/platform: linux,host

--- a/core/mondoo-openssl-incident-response.mql.yaml
+++ b/core/mondoo-openssl-incident-response.mql.yaml
@@ -1,6 +1,6 @@
 packs:
   - uid: mondoo-openssl-incident-response
-    name: OpenSSL Incident Response by Mondoo
+    name: OpenSSL Incident Response Pack by Mondoo
     version: 1.0.0
     tags:
       mondoo.com/platform: linux,host

--- a/core/mondoo-windows-incident-response.mql.yaml
+++ b/core/mondoo-windows-incident-response.mql.yaml
@@ -1,6 +1,6 @@
 packs:
   - uid: mondoo-windows-incident-response
-    name: Windows Incident Response by Mondoo
+    name: Windows Incident Response Pack by Mondoo
     version: 1.0.0
     tags:
       mondoo.com/platform: windows,host

--- a/extra/mondoo-googleworkplace-incident-response.mql.yaml
+++ b/extra/mondoo-googleworkplace-incident-response.mql.yaml
@@ -1,6 +1,6 @@
 packs:
   - uid: mondoo-googleworkspace-incident-response
-    name: Google Workspace Incident Response by Mondoo
+    name: Google Workspace Incident Response Pack by Mondoo
     version: 1.0.0
     tags:
       mondoo.com/platform: google-workspace,saas

--- a/extra/mondoo-okta-incident-response.mql.yaml
+++ b/extra/mondoo-okta-incident-response.mql.yaml
@@ -1,6 +1,6 @@
 packs:
   - uid: mondoo-okta-incident-response
-    name: Okta Incident Response by Mondoo
+    name: Okta Incident Response Pack by Mondoo
     version: 1.0.0
     tags:
       mondoo.com/platform: okta-org,saas

--- a/extra/mondoo-slack-incident-response.mql.yaml
+++ b/extra/mondoo-slack-incident-response.mql.yaml
@@ -1,6 +1,6 @@
 packs:
   - uid: mondoo-slack-incident-response
-    name: Slack Incident Response by Mondoo
+    name: Slack Incident Response Pack by Mondoo
     version: 1.0.0
     tags:
       mondoo.com/platform: slack-team,saas


### PR DESCRIPTION
They all use the same pattern now. This makes search in Policy Hub (or registry) much better.