### PR TITLE
Unify the wording for each query pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# cnquery-packs
+# cnquery Query Packs
 
-This project contains query packs used with [`cnquery`](https://github.com/mondoohq/cnquery). We've organized them into these directories:
+This project contains inventory and incident response query packs for [`cnquery`](https://github.com/mondoohq/cnquery). We've organized them into these directories:
 
 - [core](core) - Core packs contain baseline queries such as incidence response probes for different targets. Core query packs are maintained by Mondoo and have strict quality requirements.
 - [extra](extra) - Extra packs are are a mix of community- and Mondoo-maintained queries that are outside Mondoo's core support tier.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project contains inventory and incident response query packs for [`cnquery`](https://github.com/mondoohq/cnquery). We've organized them into these directories:
 
-- [core](core) - Core packs contain baseline queries such as incidence response probes for different targets. Core query packs are maintained by Mondoo and have strict quality requirements.
+- [core](core) - Core packs contain baseline queries such as incident response probes for different targets. Core query packs are maintained by Mondoo and have strict quality requirements.
 - [extra](extra) - Extra packs are are a mix of community- and Mondoo-maintained queries that are outside Mondoo's core support tier.
 - [community](community) - Community packs are primarily maintained by the community with support from the Mondoo team. Community packs may move to extra or core over time.
 

--- a/core/mondoo-aws-incident-response.mql.yaml
+++ b/core/mondoo-aws-incident-response.mql.yaml
@@ -85,7 +85,7 @@ packs:
               accessKey2LastRotated
             }
       - uid: mondoo-incident-response-aws-iam-administrator-access
-        title: Retrieve data on IAM Users, Groups, and Roles where AdministratorAccess policy is attached
+        title: Retrieve data on IAM users, groups, and roles to which the AdministratorAccess policy is attached
         docs:
           desc: |
             This query retrieves all IAM users, groups, and roles with the `AdministratorAccess` role attached.

--- a/core/mondoo-aws-incident-response.mql.yaml
+++ b/core/mondoo-aws-incident-response.mql.yaml
@@ -88,7 +88,7 @@ packs:
         title: Retrieve data on IAM Users, Groups, and Roles where AdministratorAccess policy is attached
         docs:
           desc: |
-            This query retrieves all IAM Users, Groups, and Roles with the `AdministratorAccess` role attached.
+            This query retrieves all IAM users, groups, and roles with the `AdministratorAccess` role attached.
         query: |
           aws.iam.attachedPolicies.
             where( arn == "arn:aws:iam::aws:policy/AdministratorAccess" ) { 

--- a/core/mondoo-aws-incident-response.mql.yaml
+++ b/core/mondoo-aws-incident-response.mql.yaml
@@ -100,7 +100,7 @@ packs:
         title: Retrieve data on IAM Users, Groups, and Roles where any 'FullAccess' policy is attached
         docs:
           desc: |
-            This query retrieves all IAM Users, Groups, and Roles that have any one of the AWS FullAccess roles attached.
+            This query retrieves all IAM users, croups, and roles that have any one of the AWS FullAccess roles attached.
         query: |
           aws.iam.policies.
             where( name == /FullAccess/i && attachmentCount != 0) { 

--- a/core/mondoo-aws-incident-response.mql.yaml
+++ b/core/mondoo-aws-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ### Overview
 
-        The AWS Incident Response Pack by Mondoo query pack gathers data about AWS services and resources for investigation during a security incident.
+        The AWS Incident Response Pack by Mondoo query pack retrieves data about AWS services and resources for investigation during a security incident.
 
         ### Run query pack
 
@@ -25,20 +25,20 @@ packs:
       - asset.platform == "aws"
     queries:
       - uid: mondoo-incident-response-aws-account-id
-        title: Gather AWS account ID
+        title: Retrieve AWS account ID
         query: |
           aws.account.id
       - uid: mondoo-incident-response-aws-enabled-regions
-        title: Gather all regions enabled in the AWS account 
+        title: Retrieve all regions enabled in the AWS account 
         docs: 
           desc: |
-            This query gathers a list of all AWS regions enabled in the account
+            This query retrieves all AWS regions enabled in the account
         query: aws { regions }
       - uid: mondoo-incident-response-aws-user-info
-        title: Gather data for users with console access
+        title: Retrieve data for users with console access
         docs:
           desc: |
-            This query gathers data for users with console access. The following fields are gathered:
+            This query retrieves data for users with console access. The following fields are retrieved:
 
             ```
             properties['user'] 
@@ -55,10 +55,10 @@ packs:
               mfaActive 
             }
       - uid: mondoo-incident-response-aws-iam-users-multiple-keys
-        title: Gather data for IAM users with API access
+        title: Retrieve data for IAM users with API access
         docs:
           desc: |
-            This query gathers all of the IAM users that have API access along with the following fields:
+            This query retrieves all of the IAM users that have API access along with the following fields:
 
             ```
             properties['user']
@@ -85,10 +85,10 @@ packs:
               accessKey2LastRotated
             }
       - uid: mondoo-incident-response-aws-iam-administrator-access
-        title: Gather data on IAM Users, Groups, and Roles where AdministratorAccess policy is attached
+        title: Retrieve data on IAM Users, Groups, and Roles where AdministratorAccess policy is attached
         docs:
           desc: |
-            This query gathers all IAM Users, Groups, and Roles that have the `AdministratorAccess` role attached.
+            This query retrieves all IAM Users, Groups, and Roles that have the `AdministratorAccess` role attached.
         query: |
           aws.iam.attachedPolicies.
             where( arn == "arn:aws:iam::aws:policy/AdministratorAccess" ) { 
@@ -97,10 +97,10 @@ packs:
               attachedRoles 
             }
       - uid: mondoo-incident-response-aws-iam-full-access
-        title: Gather data on IAM Users, Groups, and Roles where any 'FullAccess' policy is attached
+        title: Retrieve data on IAM Users, Groups, and Roles where any 'FullAccess' policy is attached
         docs:
           desc: |
-            This query gathers all IAM Users, Groups, and Roles that have any one of the AWS FullAccess roles attached.
+            This query retrieves all IAM Users, Groups, and Roles that have any one of the AWS FullAccess roles attached.
         query: |
           aws.iam.policies.
             where( name == /FullAccess/i && attachmentCount != 0) { 
@@ -113,10 +113,10 @@ packs:
             }
 
       - uid: mondoo-incident-response-aws-ec2-instances-public-ip
-        title: Gather EC2 instances that have a public IP address
+        title: Retrieve EC2 instances that have a public IP address
         docs:
           desc: |
-            This query gathers all EC2 instances that have a publicIp address attached along with the following fields:
+            This query retrieves all EC2 instances that have a publicIp address attached along with the following fields:
 
             ```
             arn 
@@ -153,10 +153,10 @@ packs:
               tags
             }
       - uid: mondoo-incident-response-aws-ec2-instances-without-tags
-        title: Gather EC2 instances that do not have tags configured
+        title: Retrieve EC2 instances that do not have tags configured
         docs: 
           desc: |
-            This query gathers all EC2 instances that do not have tags configured, along with the following fields:
+            This query retrieves all EC2 instances that do not have tags configured, along with the following fields:
 
             ```mql
             instanceId 
@@ -177,10 +177,10 @@ packs:
               state
             }
       - uid: mondoo-incident-response-aws-s3-buckets-public
-        title: Gather all S3 buckets that are public
+        title: Retrieve all S3 buckets that are public
         docs:
           desc: |
-            This query gathers all S3 buckets that are configured with public access, and returns the following fields:
+            This query retrieves all S3 buckets that are configured with public access, and returns the following fields:
 
             ```mql
             arn

--- a/core/mondoo-aws-incident-response.mql.yaml
+++ b/core/mondoo-aws-incident-response.mql.yaml
@@ -97,7 +97,7 @@ packs:
               attachedRoles 
             }
       - uid: mondoo-incident-response-aws-iam-full-access
-        title: Retrieve data on IAM Users, Groups, and Roles where any 'FullAccess' policy is attached
+        title: Retrieve data on IAM users, groups, and roles to which any 'FullAccess' policy is attached
         docs:
           desc: |
             This query retrieves all IAM users, croups, and roles that have any one of the AWS FullAccess roles attached.

--- a/core/mondoo-aws-incident-response.mql.yaml
+++ b/core/mondoo-aws-incident-response.mql.yaml
@@ -88,7 +88,7 @@ packs:
         title: Retrieve data on IAM Users, Groups, and Roles where AdministratorAccess policy is attached
         docs:
           desc: |
-            This query retrieves all IAM Users, Groups, and Roles that have the `AdministratorAccess` role attached.
+            This query retrieves all IAM Users, Groups, and Roles with the `AdministratorAccess` role attached.
         query: |
           aws.iam.attachedPolicies.
             where( arn == "arn:aws:iam::aws:policy/AdministratorAccess" ) { 
@@ -116,7 +116,7 @@ packs:
         title: Retrieve EC2 instances that have a public IP address
         docs:
           desc: |
-            This query retrieves all EC2 instances that have a publicIp address attached along with the following fields:
+            This query retrieves all EC2 instances that have a public IP address attached along with the following fields:
 
             ```
             arn 
@@ -180,7 +180,7 @@ packs:
         title: Retrieve all S3 buckets that are public
         docs:
           desc: |
-            This query retrieves all S3 buckets that are configured with public access, and returns the following fields:
+            This query retrieves all S3 buckets that are configured with public access and returns the following fields:
 
             ```mql
             arn
@@ -202,5 +202,3 @@ packs:
               tags
               policy {*}
             }
-
-          

--- a/core/mondoo-aws-inventory.mql.yaml
+++ b/core/mondoo-aws-inventory.mql.yaml
@@ -55,7 +55,7 @@ packs:
         title: Retrieve data on all attached IAM Policies
         docs:
           desc: |
-            This query retrieves all IAM policies that are attached to either a User, Group, or Role.
+            This query retrieves all IAM policies attached to a User, Group, or Role.
         query: |
           aws.iam.policies.
             where( attachmentCount > 0 ) { 
@@ -182,6 +182,3 @@ packs:
       - uid: mondoo-asset-inventory-aws-cloudtrail-trails
         title: Retrieve the configuration for all AWS CloudTrail trails
         query: aws.cloudtrail { trails {*}}
-
-
-          

--- a/core/mondoo-aws-inventory.mql.yaml
+++ b/core/mondoo-aws-inventory.mql.yaml
@@ -55,7 +55,7 @@ packs:
         title: Retrieve data on all attached IAM Policies
         docs:
           desc: |
-            This query retrieves all IAM policies attached to a User, Group, or Role.
+            This query retrieves all IAM policies attached to a user, group, or role.
         query: |
           aws.iam.policies.
             where( attachmentCount > 0 ) { 

--- a/core/mondoo-aws-inventory.mql.yaml
+++ b/core/mondoo-aws-inventory.mql.yaml
@@ -10,52 +10,52 @@ packs:
       mondoo.com/category: best-practices
     docs:
       desc: |
-        The AWS Asset Inventory by Mondoo query pack gathers information about AWS accounts for asset inventory.
+        The AWS Asset Inventory by Mondoo query pack retrieves information about AWS accounts for asset inventory.
     filters:
       - asset.platform == "aws"
     queries:
       - uid: mondoo-asset-inventory-aws-account-id
-        title: Gather AWS account ID
+        title: Retrieve AWS account ID
         query: |
           aws.account.id
       - uid: mondoo-asset-inventory-aws-enabled-regions
-        title: Gather all regions enabled in the AWS account 
+        title: Retrieve all regions enabled in the AWS account 
         docs: 
           desc: |
-            This query gathers a list of all AWS regions enabled in the account
+            This query retrieves all AWS regions enabled in the account
         query: aws { regions }
       - uid: mondoo-asset-inventory-aws-vpcs
-        title: Gather data on all VPCs
+        title: Retrieve data on all VPCs
         docs: 
           desc: |
-            This query gathers all of the configuration data for AWS VPCs
+            This query retrieves all of the configuration data for AWS VPCs
         query: aws { vpcs {*} }
       - uid: mondoo-asset-inventory-aws-iam-users
-        title: Gather data for all IAM users
+        title: Retrieve data for all IAM users
         docs:
           desc: |
-            This query gathers data for all IAM users
+            This query retrieves data for all IAM users
         query: |
           aws.iam { users {*} }
       - uid: mondoo-asset-inventory-aws-iam-groups
-        title: Gather data for IAM groups
+        title: Retrieve data for IAM groups
         docs:
           desc: |
-            This query gathers all of the IAM groups.
+            This query retrieves all of the IAM groups.
         query: |
           aws.iam { groups {*} }
       - uid: mondoo-asset-inventory-aws-iam-roles
-        title: Gather data on all IAM Roles.
+        title: Retrieve data on all IAM Roles.
         docs:
           desc: |
-            This query gathers all IAM Roles
+            This query retrieves all IAM Roles
         query: |
           aws.iam { roles {*} }
       - uid: mondoo-asset-inventory-aws-iam-policies
-        title: Gather data on all attached IAM Policies
+        title: Retrieve data on all attached IAM Policies
         docs:
           desc: |
-            This query gathers all IAM policies that are attached to either a User, Group, or Role.
+            This query retrieves all IAM policies that are attached to either a User, Group, or Role.
         query: |
           aws.iam.policies.
             where( attachmentCount > 0 ) { 
@@ -67,21 +67,21 @@ packs:
               scope
             }
       - uid: mondoo-asset-inventory-aws-ec2-security-groups
-        title: Gather data on all AWS EC2 Security Groups
+        title: Retrieve data on all AWS EC2 Security Groups
         docs:
           desc: |
-            This query gathers all AWS EC2 Security Groups
+            This query retrieves all AWS EC2 Security Groups
         query: |
          aws.ec2.securityGroups {*}
       - uid: mondoo-asset-inventory-aws-ec2-volumes
-        title: Gather data on all AWS EC2 volumes
+        title: Retrieve data on all AWS EC2 volumes
         docs:
           desc: |
-            This query gathers all AWS EC2 volumes
+            This query retrieves all AWS EC2 volumes
         query: |
          aws.ec2.volumes {*}
-      - uid: mondoo-asset-inventory-aws-ec2-gather-all-data
-        title: Gather the configuration for all EC2 instances
+      - uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data
+        title: Retrieve the configuration for all EC2 instances
         query: |
           aws.ec2.instances {
             arn
@@ -110,7 +110,7 @@ packs:
             keypair
           }
       - uid: mondoo-asset-inventory-aws-rds-dbclusters-all-data
-        title: Gather the configuration for all RDS Database Clusters
+        title: Retrieve the configuration for all RDS Database Clusters
         query: |
           aws.rds {
             dbClusters {
@@ -122,7 +122,7 @@ packs:
             }
           }
       - uid: mondoo-asset-inventory-aws-rds-dbinstances-all-data
-        title: Gather the configuration for all RDS Database Instances
+        title: Retrieve the configuration for all RDS Database Instances
         query: |
           aws.rds {
             dbInstances {
@@ -145,8 +145,8 @@ packs:
               status
             }
           }
-      - uid: mondoo-asset-inventory-aws-s3-gather-all-data
-        title: Gather the configuration for all S3 buckets
+      - uid: mondoo-asset-inventory-aws-s3-retrieve-all-data
+        title: Retrieve the configuration for all S3 buckets
         query: |
           aws.s3.buckets {
             arn
@@ -168,19 +168,19 @@ packs:
             exists
           }
       - uid: mondoo-asset-inventory-aws-eks-clusterss
-        title: Gather the configuration for all AWS EKS clusters
+        title: Retrieve the configuration for all AWS EKS clusters
         query: aws.eks { clusters {*} }
       - uid: mondoo-asset-inventory-aws-lambda
-        title: Gather the configuration for all AWS lambda functions
+        title: Retrieve the configuration for all AWS lambda functions
         query: aws.lambda { functions {*} }
       - uid: mondoo-asset-inventory-aws-access-analyzer
-        title: Gather the configuration for all AWS Access Analyzers
+        title: Retrieve the configuration for all AWS Access Analyzers
         query: aws.accessAnalyzer { analyzers {*} }
       - uid: mondoo-asset-inventory-aws-acm-certificates
-        title: Gather the configuration for all AWS Certificate Manager certificates
+        title: Retrieve the configuration for all AWS Certificate Manager certificates
         query: aws.acm { certificates {*} }
       - uid: mondoo-asset-inventory-aws-cloudtrail-trails
-        title: Gather the configuration for all AWS CloudTrail trails
+        title: Retrieve the configuration for all AWS CloudTrail trails
         query: aws.cloudtrail { trails {*}}
 
 

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -73,7 +73,7 @@ packs:
             This query retrieves the data for all running GCP compute instances in a GCP project
         query: gcp.compute.instances.where( status == "RUNNING" ) { * }
       - uid: mondoo-asset-inventory-gcp-compute-instances-public
-        title: Retrieve data on public GCP Compute instances
+        title: Retrieve data on public GCP Compute Engine instances
         docs:
           desc: |
             This query retrieves the data for all GCP compute instances that have been configured with an external IP address. 

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -87,7 +87,7 @@ packs:
             This query retrieves a count of GCP compute networks configured in a GCP project
         query: gcp.compute.networks.length
       - uid: mondoo-asset-inventory-gcp-compute-networks-data
-        title: Retrieve data for all GCP compute networks in a GCP project
+        title: Retrieve data for all GCP Compute Engine networks in a GCP project
         docs: 
           desc: |
             This query retrieves the data for all GCP compute networks configured in a GCP project

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -10,12 +10,12 @@ packs:
       mondoo.com/category: best-practices
     docs:
       desc: |
-        The GCP Asset Inventory by Mondoo query pack gathers information about GCP projects for asset inventory.
+        The GCP Asset Inventory by Mondoo query pack retrieves information about GCP projects for asset inventory.
     filters:
       - asset.platform == "gcp" || asset.platform == "gcp-project"
     queries:
       - uid: mondoo-asset-inventory-gcp-project-info
-        title: Gather GCP Project Information
+        title: Retrieve GCP Project Information
         query: |
           gcp.project { 
             name
@@ -25,70 +25,70 @@ packs:
             labels
           }
       - uid: mondoo-asset-inventory-gcp-project-owners
-        title: Gather data for all owners of the GCP project
+        title: Retrieve data for all owners of the GCP project
         docs:
           desc: |
-            This query gathers data for all owners of the GCP project
+            This query retrieves data for all owners of the GCP project
         query: gcp.project.iamPolicy.where( role == "roles/owner" ) { * }
       - uid: mondoo-asset-inventory-gcp-project-editors
-        title: Gather data for all editors of the GCP project
+        title: Retrieve data for all editors of the GCP project
         docs:
           desc: |
-            This query gathers data for all editors of the GCP project
+            This query retrieves data for all editors of the GCP project
         query: gcp.project.iamPolicy.where( role == "roles/editors" ) { * }
       - uid: mondoo-asset-inventory-gcp-iam-roles
-        title: Gather list of all IAM Policy roles for the GCP project
+        title: Retrieve all IAM Policy roles for the GCP project
         docs:
           desc: |
-            This query gathers a list of all roles defined for a GCP project
+            This query retrieves all roles defined for a GCP project
         query: gcp.project.iamPolicy { role }
       - uid: mondoo-asset-inventory-gcp-enabled-services
-        title: Gather all services enabled in the GCP project 
+        title: Retrieve all services enabled in the GCP project 
         docs: 
           desc: |
-            This query gathers a list of all services enabled in the GCP Project
+            This query retrieves all services enabled in the GCP Project
         query: gcp.project.services.where( enabled == true ) { * }
       - uid: mondoo-asset-inventory-gcp-gke-clusters-count
-        title: Gather count of GKE clusters in a GCP project
+        title: Retrieve count of GKE clusters in a GCP project
         docs: 
           desc: |
-            This query gathers a count of GKE clusters running in a GCP project
+            This query retrieves a count of GKE clusters running in a GCP project
         query: gcp.project.gke.clusters.length
       - uid: mondoo-asset-inventory-gcp-gke-clusters-data
-        title: Gather data on GKE clusters
+        title: Retrieve data on GKE clusters
         docs: 
           desc: |
-            This query gathers all of the configuration data for GKE clusters within a project
+            This query retrieves all of the configuration data for GKE clusters within a project
         query: gcp.project.gke.clusters { * }
       - uid: mondoo-asset-inventory-gcp-compute-instances-count
-        title: Gather a count of GCP compute instances in a GCP project
+        title: Retrieve a count of GCP compute instances in a GCP project
         docs: 
           desc: |
-            This query gathers a count of running GCP compute instances in a GCP project
+            This query retrieves a count of running GCP compute instances in a GCP project
         query: gcp.compute.instances.where( status == "RUNNING" ).length
       - uid: mondoo-asset-inventory-gcp-compute-instances-data
-        title: Gather data from all running GCP compute instances in a GCP project
+        title: Retrieve data from all running GCP compute instances in a GCP project
         docs: 
           desc: |
-            This query gathers the data for all running GCP compute instances in a GCP project
+            This query retrieves the data for all running GCP compute instances in a GCP project
         query: gcp.compute.instances.where( status == "RUNNING" ) { * }
       - uid: mondoo-asset-inventory-gcp-compute-instances-public
-        title: Gather data on public GCP Compute instances
+        title: Retrieve data on public GCP Compute instances
         docs:
           desc: |
-            This query gathers the data for all GCP compute instances that have been configured with an external IP address. 
+            This query retrieves the data for all GCP compute instances that have been configured with an external IP address. 
         query: |
           gcp.compute.instances
             .where( networkInterfaces[0]['accessConfigs'][0]['name'] == "External NAT" ) { * }
       - uid: mondoo-asset-inventory-gcp-compute-networks-count
-        title: Gather a count of GCP compute networks in a GCP project
+        title: Retrieve a count of GCP compute networks in a GCP project
         docs: 
           desc: |
-            This query gathers a count of GCP compute networks configured in a GCP project
+            This query retrieves a count of GCP compute networks configured in a GCP project
         query: gcp.compute.networks.length
       - uid: mondoo-asset-inventory-gcp-compute-networks-data
-        title: Gather data for all GCP compute networks in a GCP project
+        title: Retrieve data for all GCP compute networks in a GCP project
         docs: 
           desc: |
-            This query gathers the data for all GCP compute networks configured in a GCP project
+            This query retrieves the data for all GCP compute networks configured in a GCP project
         query: gcp.compute.networks { * }

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -84,7 +84,7 @@ packs:
         title: Retrieve a count of GCP Compute Engine networks in a GCP project
         docs: 
           desc: |
-            This query retrieves a count of GCP compute networks configured in a GCP project
+            This query retrieves a count of GCP Compute Engine networks configured in a GCP project
         query: gcp.compute.networks.length
       - uid: mondoo-asset-inventory-gcp-compute-networks-data
         title: Retrieve data for all GCP Compute Engine networks in a GCP project

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -76,7 +76,7 @@ packs:
         title: Retrieve data on public GCP Compute Engine instances
         docs:
           desc: |
-            This query retrieves the data for all GCP compute instances that have been configured with an external IP address. 
+            This query retrieves the data for all GCP Compute Engine instances that have been configured with an external IP address. 
         query: |
           gcp.compute.instances
             .where( networkInterfaces[0]['accessConfigs'][0]['name'] == "External NAT" ) { * }

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -81,7 +81,7 @@ packs:
           gcp.compute.instances
             .where( networkInterfaces[0]['accessConfigs'][0]['name'] == "External NAT" ) { * }
       - uid: mondoo-asset-inventory-gcp-compute-networks-count
-        title: Retrieve a count of GCP compute networks in a GCP project
+        title: Retrieve a count of GCP Compute Engine networks in a GCP project
         docs: 
           desc: |
             This query retrieves a count of GCP compute networks configured in a GCP project

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -90,5 +90,5 @@ packs:
         title: Retrieve data for all GCP Compute Engine networks in a GCP project
         docs: 
           desc: |
-            This query retrieves the data for all GCP compute networks configured in a GCP project
+            This query retrieves the data for all GCP Compute Engine networks configured in a GCP project.
         query: gcp.compute.networks { * }

--- a/core/mondoo-github-incident-response.mql.yaml
+++ b/core/mondoo-github-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ### Overview
 
-        The GitHub Organization Incident Response Pack by Mondoo query pack gathers configuration data about GitHub Organizations and the repositories within for investigation during a security incident.
+        The GitHub Organization Incident Response Pack by Mondoo query pack retrieves configuration data about GitHub Organizations and the repositories within for investigation during a security incident.
 
         ### Prerequisites
 

--- a/core/mondoo-github-incident-response.mql.yaml
+++ b/core/mondoo-github-incident-response.mql.yaml
@@ -95,7 +95,7 @@ packs:
         title: Retrieve GitHub Organization private repositories
         docs: 
           desc: |
-            This query retrieves all of the public repositories within the GitHub organization. The query returns the repo's name and returns whether the default branch is [protected](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) using protection rules.
+            This query retrieves all of the public repositories within the GitHub organization. The query returns the repo's name and whether the default branch is [protected](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) using protection rules.
         query: |
           github.organization.repositories.
             where( private == false ) { 

--- a/core/mondoo-github-incident-response.mql.yaml
+++ b/core/mondoo-github-incident-response.mql.yaml
@@ -45,7 +45,7 @@ packs:
         title: Retrieve GitHub Organization MFA status 
         docs:
           desc: |
-            This query retrieves the status of whether MFA is required for users of the organization. 
+            This query retrieves whether MFA is required for users of the organization.
         query: |
           github.organization.twoFactorRequirementEnabled  
       - uid: mondoo-incident-response-github-org-owners
@@ -95,7 +95,7 @@ packs:
         title: Retrieve GitHub Organization private repositories
         docs: 
           desc: |
-            This query retrieves all of the repositories within the GitHub organization that are public. The query returns the name of the repo, and returns whether the default branch is [protected](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) using protection rules. 
+            This query retrieves all of the public repositories within the GitHub organization. The query returns the repo's name and returns whether the default branch is [protected](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) using protection rules.
         query: |
           github.organization.repositories.
             where( private == false ) { 
@@ -121,5 +121,3 @@ packs:
               }
             }
           }
-
-          

--- a/core/mondoo-github-incident-response.mql.yaml
+++ b/core/mondoo-github-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ### Overview
 
-        The GitHub Organization Incident Response Pack by Mondoo query pack retrieves configuration data about GitHub Organizations and the repositories within for investigation during a security incident.
+        The GitHub Organization Incident Response Pack by Mondoo query pack retrieves configuration data about GitHub organizations and the repositories within them for investigation during a security incident.
 
         ### Prerequisites
 

--- a/core/mondoo-github-inventory.mql.yaml
+++ b/core/mondoo-github-inventory.mql.yaml
@@ -81,7 +81,7 @@ packs:
       desc: |
         ### Overview
 
-        The Mondoo GitHub User Inventory query pack retrieves configuration data about GitHub user.
+        The Mondoo GitHub User Inventory query pack retrieves configuration data about GitHub users.
 
         ### Prerequisites
 
@@ -150,7 +150,7 @@ packs:
       desc: |
         ### Overview
 
-        The Mondoo GitHub Repository Inventory query pack retrieves configuration data about GitHub repository.
+        The Mondoo GitHub Repository Inventory query pack retrieves configuration data about GitHub repositories.
 
         ### Prerequisites
 

--- a/core/mondoo-github-inventory.mql.yaml
+++ b/core/mondoo-github-inventory.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ### Overview
 
-        The GitHub Organization Inventory Pack by Mondoo query pack gathers configuration data about GitHub organization.
+        The GitHub Organization Inventory Pack by Mondoo query pack retrieves configuration data about GitHub organization.
 
         ### Prerequisites
 
@@ -81,7 +81,7 @@ packs:
       desc: |
         ### Overview
 
-        The Mondoo GitHub User Inventory query pack gathers configuration data about GitHub user.
+        The Mondoo GitHub User Inventory query pack retrieves configuration data about GitHub user.
 
         ### Prerequisites
 
@@ -150,7 +150,7 @@ packs:
       desc: |
         ### Overview
 
-        The Mondoo GitHub Repository Inventory query pack gathers configuration data about GitHub repository.
+        The Mondoo GitHub Repository Inventory query pack retrieves configuration data about GitHub repository.
 
         ### Prerequisites
 

--- a/core/mondoo-github-inventory.mql.yaml
+++ b/core/mondoo-github-inventory.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ### Overview
 
-        The GitHub Organization Inventory Pack by Mondoo query pack retrieves configuration data about GitHub organization.
+        The GitHub Organization Inventory Pack by Mondoo query pack retrieves configuration data about GitHub organizations.
 
         ### Prerequisites
 

--- a/core/mondoo-kubernetes-incident-response.mql.yaml
+++ b/core/mondoo-kubernetes-incident-response.mql.yaml
@@ -45,7 +45,7 @@ packs:
       - asset.platform == "k8s-pod"
     queries:
       - uid: k8s-pod-security-context
-        title: Retrieve Pods Security Context
+        title: Retrieve Pods' Security Context
         query: |
           k8s.pod {
             ephemeralContainers {

--- a/core/mondoo-kubernetes-incident-response.mql.yaml
+++ b/core/mondoo-kubernetes-incident-response.mql.yaml
@@ -12,11 +12,11 @@ packs:
       - asset.platform == "kubernetes" || asset.platform == "k8s-cluster"
     queries:
       - uid: k8s-cluster-version
-        title: Gather Kubernetes Cluster Version
+        title: Retrieve Kubernetes Cluster Version
         query: |
           k8s.serverVersion
       - uid: role-bindings-with-cluster-admin-permissions
-        title: Gather Role Bindings with cluster-admin Permissions
+        title: Retrieve Role Bindings with cluster-admin Permissions
         query: |
           k8s.rolebindings.where(roleRef["kind"] == "ClusterRole" && roleRef["name"] == "cluster-admin") {
             name
@@ -25,7 +25,7 @@ packs:
             roleRef
           }
       - uid: clusterrole-bindings-with-cluster-admin-permissions
-        title: Gather ClusterRole Bindings with cluster-admin Permissions
+        title: Retrieve ClusterRole Bindings with cluster-admin Permissions
         query: |
           k8s.clusterrolebindings.where(roleRef["kind"] == "ClusterRole" && roleRef["name"] == "cluster-admin") {
             name
@@ -45,7 +45,7 @@ packs:
       - asset.platform == "k8s-pod"
     queries:
       - uid: k8s-pod-security-context
-        title: Gather Pods Security Context
+        title: Retrieve Pods Security Context
         query: |
           k8s.pod {
             ephemeralContainers {
@@ -59,7 +59,7 @@ packs:
             }
           }
       - uid: k8s-pod-container
-        title: Gather Container Image Information
+        title: Retrieve Container Image Information
         tags:
           mondoo.com/platform: kubernetes
           mondoo.com/category: security
@@ -118,7 +118,7 @@ packs:
       - asset.platform == "k8s-cronjob"
     queries:
       - uid: k8s-cronjobs
-        title: Gather CronJobs
+        title: Retrieve CronJobs
         query: |
           k8s.cronjob { 
             name

--- a/core/mondoo-kubernetes-incident-response.mql.yaml
+++ b/core/mondoo-kubernetes-incident-response.mql.yaml
@@ -25,7 +25,7 @@ packs:
             roleRef
           }
       - uid: clusterrole-bindings-with-cluster-admin-permissions
-        title: Retrieve ClusterRole Bindings with cluster-admin Permissions
+        title: Retrieve ClusterRoleBindings with cluster-admin permissions
         query: |
           k8s.clusterrolebindings.where(roleRef["kind"] == "ClusterRole" && roleRef["name"] == "cluster-admin") {
             name
@@ -59,7 +59,7 @@ packs:
             }
           }
       - uid: k8s-pod-container
-        title: Retrieve Container Image Information
+        title: Retrieve container image information
         tags:
           mondoo.com/platform: kubernetes
           mondoo.com/category: security

--- a/core/mondoo-kubernetes-incident-response.mql.yaml
+++ b/core/mondoo-kubernetes-incident-response.mql.yaml
@@ -16,7 +16,7 @@ packs:
         query: |
           k8s.serverVersion
       - uid: role-bindings-with-cluster-admin-permissions
-        title: Retrieve Role Bindings with cluster-admin Permissions
+        title: Retrieve role bindings with cluster-admin permissions
         query: |
           k8s.rolebindings.where(roleRef["kind"] == "ClusterRole" && roleRef["name"] == "cluster-admin") {
             name

--- a/core/mondoo-kubernetes-inventory.mql.yaml
+++ b/core/mondoo-kubernetes-inventory.mql.yaml
@@ -21,7 +21,7 @@ packs:
         ## Join the community!
         Our goal is to build query packs that are simple to deploy, and provide accurate and useful data. 
         
-        If you have any suggestions on how to improve this query pack, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
+        If you have any suggestions on improving this query pack, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
     filters:
       - asset.platform == "kubernetes" || asset.platform == "k8s-cluster"
     queries:
@@ -181,5 +181,3 @@ packs:
         title: Retrieve Container Information
         query: |
           k8s.replicaset.containers { * }
-
-

--- a/core/mondoo-kubernetes-inventory.mql.yaml
+++ b/core/mondoo-kubernetes-inventory.mql.yaml
@@ -10,7 +10,7 @@ packs:
       mondoo.com/category: best-practices
     docs:
       desc: |
-        The Kubernetes Cluster Inventory Pack by Mondoo pack is designed to gather data about a Kubernetes Cluster for asset inventory. 
+        The Kubernetes Cluster Inventory Pack by Mondoo pack is designed to retrieve data about a Kubernetes Cluster for asset inventory. 
 
         To run this pack for a Kubernetes Cluster:
 
@@ -26,19 +26,19 @@ packs:
       - asset.platform == "kubernetes" || asset.platform == "k8s-cluster"
     queries:
       - uid: k8s-cluster-version
-        title: Gather Kubernetes Cluster Version
+        title: Retrieve Kubernetes Cluster Version
         query: |
           k8s.serverVersion
       - uid: k8s-cluster-namespaces
-        title: Gather Kubernetes Cluster Namespaces
+        title: Retrieve Kubernetes Cluster Namespaces
         query: |
           k8s.namespaces{ * }
       - uid: k8s-cluster-nodes
-        title: Gather Cluster Nodes
+        title: Retrieve Cluster Nodes
         query: |
           k8s.nodes { * }
       - uid: k8s-cluster-clusterroles
-        title: Gather Cluster RBAC ClusterRoles
+        title: Retrieve Cluster RBAC ClusterRoles
         query: |
           k8s.clusterroles { * }      
   - uid: mondoo-kubernetes-pods-inventory
@@ -54,11 +54,11 @@ packs:
       - asset.platform == "k8s-pod"
     queries:
       - uid: k8s-pod
-        title: Gather Pod Information
+        title: Retrieve Pod Information
         query: |
           k8s.pod { * }
       - uid: k8s-pod-container
-        title: Gather Container Information
+        title: Retrieve Container Information
         query: |
           k8s.pod.containers { * }
   - uid: mondoo-kubernetes-deployments-inventory
@@ -74,11 +74,11 @@ packs:
       - asset.platform == "k8s-deployment"
     queries:
       - uid: k8s-deployment
-        title: Gather Deployment Information
+        title: Retrieve Deployment Information
         query: |
           k8s.deployment { * }
       - uid: k8s-deployment-container
-        title: Gather Container Information
+        title: Retrieve Container Information
         query: |
           k8s.deployment.containers { * }
   - uid: mondoo-kubernetes-cronjobs-inventory
@@ -94,11 +94,11 @@ packs:
       - asset.platform == "k8s-cronjob"
     queries:
       - uid: k8s-cronjob
-        title: Gather CronJob Information
+        title: Retrieve CronJob Information
         query: |
           k8s.cronjob { * }
       - uid: k8s-cronjob-container
-        title: Gather Container Information
+        title: Retrieve Container Information
         query: |
           k8s.cronjob.containers { * }
   - uid: mondoo-kubernetes-jobs-inventory
@@ -114,11 +114,11 @@ packs:
       - asset.platform == "k8s-job"
     queries:
       - uid: k8s-job
-        title: Gather Job Information
+        title: Retrieve Job Information
         query: |
           k8s.job { * }
       - uid: k8s-job-container
-        title: Gather Container Information
+        title: Retrieve Container Information
         query: |
           k8s.job.containers { * }
   - uid: mondoo-kubernetes-daemonsets-inventory
@@ -134,11 +134,11 @@ packs:
       - asset.platform == "k8s-daemonset"
     queries:
       - uid: k8s-daemonset
-        title: Gather DaemonSet Information
+        title: Retrieve DaemonSet Information
         query: |
           k8s.daemonset { * }
       - uid: k8s-daemonset-container
-        title: Gather Container Information
+        title: Retrieve Container Information
         query: |
           k8s.daemonset.containers { * }
   - uid: mondoo-kubernetes-statefulsets-inventory
@@ -154,11 +154,11 @@ packs:
       - asset.platform == "k8s-statefulset"
     queries:
       - uid: k8s-statefulset
-        title: Gather StatefulSet Information
+        title: Retrieve StatefulSet Information
         query: |
           k8s.statefulset { * }
       - uid: k8s-statefulset-container
-        title: Gather Container Information
+        title: Retrieve Container Information
         query: |
           k8s.statefulset.containers { * }
   - uid: mondoo-kubernetes-replicasets-inventory
@@ -174,11 +174,11 @@ packs:
       - asset.platform == "k8s-replicaset"
     queries:
       - uid: k8s-replicaset
-        title: Gather ReplicaSet Information
+        title: Retrieve ReplicaSet Information
         query: |
           k8s.replicaset { * }
       - uid: k8s-replicaset-container
-        title: Gather Container Information
+        title: Retrieve Container Information
         query: |
           k8s.replicaset.containers { * }
 

--- a/core/mondoo-kubernetes-inventory.mql.yaml
+++ b/core/mondoo-kubernetes-inventory.mql.yaml
@@ -21,7 +21,7 @@ packs:
         ## Join the community!
         Our goal is to build query packs that are simple to deploy, and provide accurate and useful data. 
         
-        If you have any suggestions on improving this query pack, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
+        If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
     filters:
       - asset.platform == "kubernetes" || asset.platform == "k8s-cluster"
     queries:

--- a/core/mondoo-kubernetes-inventory.mql.yaml
+++ b/core/mondoo-kubernetes-inventory.mql.yaml
@@ -26,19 +26,19 @@ packs:
       - asset.platform == "kubernetes" || asset.platform == "k8s-cluster"
     queries:
       - uid: k8s-cluster-version
-        title: Retrieve Kubernetes Cluster Version
+        title: Retrieve Kubernetes cluster version
         query: |
           k8s.serverVersion
       - uid: k8s-cluster-namespaces
-        title: Retrieve Kubernetes Cluster Namespaces
+        title: Retrieve Kubernetes cluster namespaces
         query: |
           k8s.namespaces{ * }
       - uid: k8s-cluster-nodes
-        title: Retrieve Cluster Nodes
+        title: Retrieve cluster modes
         query: |
           k8s.nodes { * }
       - uid: k8s-cluster-clusterroles
-        title: Retrieve Cluster RBAC ClusterRoles
+        title: Retrieve cluster RBAC ClusterRoles
         query: |
           k8s.clusterroles { * }      
   - uid: mondoo-kubernetes-pods-inventory
@@ -54,11 +54,11 @@ packs:
       - asset.platform == "k8s-pod"
     queries:
       - uid: k8s-pod
-        title: Retrieve Pod Information
+        title: Retrieve Pod information
         query: |
           k8s.pod { * }
       - uid: k8s-pod-container
-        title: Retrieve Container Information
+        title: Retrieve container information
         query: |
           k8s.pod.containers { * }
   - uid: mondoo-kubernetes-deployments-inventory
@@ -74,11 +74,11 @@ packs:
       - asset.platform == "k8s-deployment"
     queries:
       - uid: k8s-deployment
-        title: Retrieve Deployment Information
+        title: Retrieve deployment information
         query: |
           k8s.deployment { * }
       - uid: k8s-deployment-container
-        title: Retrieve Container Information
+        title: Retrieve container information
         query: |
           k8s.deployment.containers { * }
   - uid: mondoo-kubernetes-cronjobs-inventory
@@ -94,11 +94,11 @@ packs:
       - asset.platform == "k8s-cronjob"
     queries:
       - uid: k8s-cronjob
-        title: Retrieve CronJob Information
+        title: Retrieve CronJob information
         query: |
           k8s.cronjob { * }
       - uid: k8s-cronjob-container
-        title: Retrieve Container Information
+        title: Retrieve container information
         query: |
           k8s.cronjob.containers { * }
   - uid: mondoo-kubernetes-jobs-inventory
@@ -114,11 +114,11 @@ packs:
       - asset.platform == "k8s-job"
     queries:
       - uid: k8s-job
-        title: Retrieve Job Information
+        title: Retrieve Job information
         query: |
           k8s.job { * }
       - uid: k8s-job-container
-        title: Retrieve Container Information
+        title: Retrieve container information
         query: |
           k8s.job.containers { * }
   - uid: mondoo-kubernetes-daemonsets-inventory
@@ -134,11 +134,11 @@ packs:
       - asset.platform == "k8s-daemonset"
     queries:
       - uid: k8s-daemonset
-        title: Retrieve DaemonSet Information
+        title: Retrieve DaemonSet information
         query: |
           k8s.daemonset { * }
       - uid: k8s-daemonset-container
-        title: Retrieve Container Information
+        title: Retrieve container information
         query: |
           k8s.daemonset.containers { * }
   - uid: mondoo-kubernetes-statefulsets-inventory
@@ -154,11 +154,11 @@ packs:
       - asset.platform == "k8s-statefulset"
     queries:
       - uid: k8s-statefulset
-        title: Retrieve StatefulSet Information
+        title: Retrieve StatefulSet information
         query: |
           k8s.statefulset { * }
       - uid: k8s-statefulset-container
-        title: Retrieve Container Information
+        title: Retrieve Container information
         query: |
           k8s.statefulset.containers { * }
   - uid: mondoo-kubernetes-replicasets-inventory
@@ -174,10 +174,10 @@ packs:
       - asset.platform == "k8s-replicaset"
     queries:
       - uid: k8s-replicaset
-        title: Retrieve ReplicaSet Information
+        title: Retrieve ReplicaSet information
         query: |
           k8s.replicaset { * }
       - uid: k8s-replicaset-container
-        title: Retrieve Container Information
+        title: Retrieve container information
         query: |
           k8s.replicaset.containers { * }

--- a/core/mondoo-linux-incident-response.mql.yaml
+++ b/core/mondoo-linux-incident-response.mql.yaml
@@ -12,31 +12,31 @@ packs:
       - asset.family.contains("linux")
     queries:
       - uid: mondoo-linux-installed-kernel
-        title: Retrieve information about installed Linux kernels
+        title: Retrieve installed Linux kernels
         query: |
           if ( mondoo.capabilities.contains('run-command') ) {
             kernel.installed
           }
       - uid: mondoo-linux-kernel-info
-        title: Retrieve information about the running Linux kernel
+        title: Retrieve the running Linux kernel
         query: |
           if ( mondoo.capabilities.contains('run-command') ) {
             kernel.info
           }
       - uid: mondoo-linux-kernel-modules
-        title: Retrieve information about Linux kernel modules
+        title: Retrieve Linux kernel modules
         query: kernel.modules { name loaded }
       - uid: mondoo-linux-processes
-        title: Retrieve information about running processes
+        title: Retrieve running processes
         query: |
           if ( mondoo.capabilities.contains('run-command') ) {
             processes { pid  command }
           }
       - uid: mondoo-linux-mounts
-        title: Retrieves list of mounted devices
+        title: Retrieve mounted devices
         query: mount.list { * } 
       - uid: mondoo-linux-listening-ports
-        title: Retrieves list of all listening ports
+        title: Retrieve all listening ports
         query: |
           if ( mondoo.capabilities.contains('run-command') ) {
             ports.listening { * }
@@ -48,8 +48,8 @@ packs:
             os.uptime
           }
       - uid: mondoo-linux-installed-packages
-        title: Retrieve list about installed packages
+        title: Retrieve installed packages
         query: packages { * }
       - uid: mondoo-linux-running-services
-        title: Retrieve list of running services
+        title: Retrieve running services
         query: services { * }

--- a/core/mondoo-linux-inventory.mql.yaml
+++ b/core/mondoo-linux-inventory.mql.yaml
@@ -10,7 +10,7 @@ packs:
       mondoo.com/category: best-practices
     docs:
       desc: |
-        The Linux Inventory Pack by Mondoo is designed to gather data about Linux hosts for asset inventory. 
+        The Linux Inventory Pack by Mondoo is designed to retrieve data about Linux hosts for asset inventory. 
 
         ## Local scan
         To run this pack locally on a linux host:
@@ -34,46 +34,46 @@ packs:
       - asset.family.contains("linux")
     queries:
       - uid: mondoo-linux-asset-info
-        title: Gather asset information
+        title: Retrieve asset information
         query: asset { kind title platform name arch runtime }
       - uid: mondoo-linux-hostname
-        title: Gather the hostname
+        title: Retrieve the hostname
         query: os.hostname
       - uid: mondoo-linux-platform
-        title: Gather the platform
+        title: Retrieve the platform
         query: platform.name
       - uid: mondoo-linux-users 
-        title: Gather regular users with shell access 
+        title: Retrieve regular users with shell access 
         query: users.where( shell != "/sbin/nologin" && uid >= 1000 ) { * }
       - uid: mondoo-linux-groups-wheel
-        title: Gather members of the wheel group
+        title: Retrieve members of the wheel group
         query: groups.where( name == "wheel") { members }
       - uid: mondoo-linux-installed-kernel
-        title: Retrieve information about installed Linux kernels
+        title: Retrieve installed Linux kernels
         query: |
           if ( mondoo.capabilities.contains('run-command') ) {
             kernel.installed
           }
       - uid: mondoo-linux-kernel-info
-        title: Retrieve information about the running Linux kernel
+        title: Retrieve the running Linux kernel
         query: |
           if ( mondoo.capabilities.contains('run-command') ) {
             kernel.info
           }
       - uid: mondoo-linux-kernel-modules
-        title: Retrieve information about Linux kernel modules
+        title: Retrieve Linux kernel modules
         query: kernel.modules { name loaded }
       - uid: mondoo-linux-processes
-        title: Retrieve information about running processes
+        title: Retrieve running processes
         query: |
           if ( mondoo.capabilities.contains('run-command') ) {
             processes { pid  command }
           }
       - uid: mondoo-linux-mounts
-        title: Retrieves list of mounted devices
+        title: Retrieve  mounted devices
         query: mount.list { * } 
       - uid: mondoo-linux-listening-ports
-        title: Retrieves list of all listening ports
+        title: Retrieve all listening ports
         query: |
           if ( mondoo.capabilities.contains('run-command') ) {
             ports.listening { * }
@@ -85,10 +85,10 @@ packs:
             os.uptime
           }
       - uid: mondoo-linux-installed-packages
-        title: Retrieve list about installed packages
+        title: Retrieve installed packages
         query: packages { * }
       - uid: mondoo-linux-running-services
-        title: Retrieve list of running services
+        title: Retrieve running services
         query: services.where( running == true ) { * }
       - uid: mondoo-linux-interface-configuration
         title: Retrieve interface configuration of the system

--- a/core/mondoo-linux-inventory.mql.yaml
+++ b/core/mondoo-linux-inventory.mql.yaml
@@ -13,7 +13,7 @@ packs:
         The Linux Inventory Pack by Mondoo is designed to retrieve data about Linux hosts for asset inventory. 
 
         ## Local scan
-        To run this pack locally on a linux host:
+        To run this pack locally on a Linux host:
 
         ```bash
         cnquery scan local -f mondoo-linux-inventory.mql.yaml
@@ -29,7 +29,7 @@ packs:
         ## Join the community!
         Our goal is to build query packs that are simple to deploy, and provide accurate and useful data. 
         
-        If you have any suggestions on how to improve this query pack, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
+        If you have any suggestions on improving this query pack, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
     filters:
       - asset.family.contains("linux")
     queries:

--- a/core/mondoo-linux-inventory.mql.yaml
+++ b/core/mondoo-linux-inventory.mql.yaml
@@ -29,7 +29,7 @@ packs:
         ## Join the community!
         Our goal is to build query packs that are simple to deploy, and provide accurate and useful data. 
         
-        If you have any suggestions on improving this query pack, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
+        If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
     filters:
       - asset.family.contains("linux")
     queries:

--- a/core/mondoo-macos-incident-response.mql.yaml
+++ b/core/mondoo-macos-incident-response.mql.yaml
@@ -18,29 +18,29 @@ packs:
         title: Retrieve regular users
         query: users.where( name != /^_/ && shell != /\/usr\/bin\/false/ ) {*}
       - uid: mondoo-macos-kernel-info
-        title: Retrieve information about the running macOS kernel
+        title: Retrieve the running macOS kernel
         query: kernel.info["version"]
       - uid: mondoo-macos-kernel-modules
-        title: Retrieve information about macOS kernel modules
+        title: Retrieve macOS kernel modules
         query: kernel.modules { name loaded }
       - uid: mondoo-macos-processes
-        title: Retrieve information about running processes
+        title: Retrieve running processes
         query: processes.list { pid  command }
       - uid: mondoo-macos-mounts
-        title: Retrieves list of mounted devices
+        title: Retrieve mounted devices
         query: mount.list { * } 
       - uid: mondoo-macos-uptime
         title: Retrieve operating system uptime
         query: os.uptime
       - uid: mondoo-macos-installed-packages
-        title: Retrieve list about installed packages
+        title: Retrieve installed packages
         query: packages.list { * }
       - uid: mondoo-macos-running-services
-        title: Retrieve list of running services
+        title: Retrieve running services
         query: services.list { * }
       - uid: mondoo-macos-alf-extensions
-        title: Retrieves the exceptions for the Application Layer Firewall on macOS
+        title: Retrieve exceptions from the Application Layer Firewall
         query: macos.alf.exceptions
       - uid: mondoo-macos-check-recommended-updates
-        title: Check for any recommended updates 
+        title: Retrieve any recommended updates
         query: parse.plist('/Library/Preferences/com.apple.SoftwareUpdate.plist').params['RecommendedUpdates']

--- a/core/mondoo-macos-inventory.mql.yaml
+++ b/core/mondoo-macos-inventory.mql.yaml
@@ -29,7 +29,7 @@ packs:
         ## Join the community!
         Our goal is to build query packs that are simple to deploy, and provide accurate and useful data. 
         
-        If you have any suggestions on improving this query pack, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
+        If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
     filters:
       - asset.platform.contains("macos")
     queries:

--- a/core/mondoo-macos-inventory.mql.yaml
+++ b/core/mondoo-macos-inventory.mql.yaml
@@ -29,7 +29,7 @@ packs:
         ## Join the community!
         Our goal is to build query packs that are simple to deploy, and provide accurate and useful data. 
         
-        If you have any suggestions on how to improve this query pack, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
+        If you have any suggestions on improving this query pack, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
     filters:
       - asset.platform.contains("macos")
     queries:
@@ -57,4 +57,3 @@ packs:
       - uid: mondoo-macos-interface-configuration
         title: Retrieve interface configuration of the system
         query: command("ifconfig").stdout
-      

--- a/core/mondoo-macos-inventory.mql.yaml
+++ b/core/mondoo-macos-inventory.mql.yaml
@@ -10,7 +10,7 @@ packs:
       mondoo.com/category: best-practices
     docs:
       desc: |
-        The macOS Inventory Pack by Mondoo is designed to gather data about macOS hosts for asset inventory. 
+        The macOS Inventory Pack by Mondoo is designed to retrieve data about macOS hosts for asset inventory. 
 
         ## Local scan
         To run this pack locally on a macOS host:
@@ -34,25 +34,25 @@ packs:
       - asset.platform.contains("macos")
     queries:
       - uid: mondoo-asset-info
-        title: Gather asset information
+        title: Retrieve asset information
         query: asset { kind title platform name arch runtime }
       - uid: mondoo-hostname
-        title: Gather the hostname
+        title: Retrieve the hostname
         query: os.hostname
       - uid: mondoo-macos-users 
-        title: Gather regular users 
+        title: Retrieve regular users 
         query: users.where( name != /^_/ && shell != "/usr/bin/false" ) { * }
       - uid: mondoo-macos-systemsetup
-        title: Gather macOS system setup 
+        title: Retrieve macOS system setup 
         query: macos.systemsetup {*}
       - uid: mondoo-macos-packages
-        title: Gather macOS packages 
+        title: Retrieve macOS packages 
         query: packages {*}
       - uid: mondoo-macos-running-services
-        title: Gather data on running services
+        title: Retrieve data on running services
         query: services.where( running == true ) { * }
       - uid: mondoo-macos-ports-listening
-        title: Gather data on listening ports 
+        title: Retrieve data on listening ports 
         query: ports.listening 
       - uid: mondoo-macos-interface-configuration
         title: Retrieve interface configuration of the system

--- a/core/mondoo-openssl-incident-response.mql.yaml
+++ b/core/mondoo-openssl-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       - asset.family.contains("linux")
     queries:
       - uid: mondoo-openssl-platform
-        title: Retrieve information about the Platform
+        title: Retrieve platform details
         query: |
           asset {
             platform
@@ -20,10 +20,10 @@ packs:
             arch
           }
       - uid: mondoo-openssl-installed-version
-        title: Retrieve list about installed ssl libraries
+        title: Retrieve installed ssl libraries
         query: packages.where(name == /ssl/)
       - uid: mondoo-openssl-listening-ports
-        title: Retrieve list of listening ports from running systems
+        title: Retrieve listening ports from running systems
         query: |
           if ( mondoo.capabilities.contains('run-command') ) {
             ports.listening { 

--- a/core/mondoo-ssl-tls-certificate-incident-response.mql.yaml
+++ b/core/mondoo-ssl-tls-certificate-incident-response.mql.yaml
@@ -48,7 +48,7 @@ packs:
             subject.commonName
           }
       - uid: mondoo-ssl-tls-certificate-incident-response-is-revoked
-        title: Retrieve revoked, verified and CA status of all certificates in the certificate chain
+        title: Retrieve revoked, verified, and CA status of all certificates in the certificate chain
         query: |
           tls.certificates {
             subject.commonName

--- a/core/mondoo-ssl-tls-certificate-incident-response.mql.yaml
+++ b/core/mondoo-ssl-tls-certificate-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ### Overview
 
-        The SSL/TLS Certificate Incident Response Pack by Mondoo query pack gathers information about SSL/TLS certificates of a domain for investigation during a security incident.
+        The SSL/TLS Certificate Incident Response Pack by Mondoo query pack retrieves information about SSL/TLS certificates of a domain for investigation during a security incident.
 
         ### Prerequisites
 
@@ -33,22 +33,22 @@ packs:
         query: |
           tls.domainName
       - uid: mondoo-ssl-tls-certificate-incident-response-versions
-        title: Retrieve list of supported SSL and TLS versions
+        title: Retrieve supported SSL and TLS versions
         query: |
           tls.versions
       - uid: mondoo-ssl-tls-certificate-incident-response-ciphers
-        title: Retrieve list of supported SSl/TLS ciphers
+        title: Retrieve supported SSl/TLS ciphers
         query: |
           tls.ciphers
       - uid: mondoo-ssl-tls-certificate-incident-response-signing-algo
-        title: Retrieve information about signature algorithm of all certificates in the certificate chain
+        title: Retrieve the signature algorithm of all certificates in the certificate chain
         query: |
           tls.certificates {
             signingAlgorithm
             subject.commonName
           }
       - uid: mondoo-ssl-tls-certificate-incident-response-is-revoked
-        title: Retrieve information about revoked, verified and CA status of all certificates in the certificate chain
+        title: Retrieve revoked, verified and CA status of all certificates in the certificate chain
         query: |
           tls.certificates {
             subject.commonName

--- a/core/mondoo-vmware-incident-response.mql.yaml
+++ b/core/mondoo-vmware-incident-response.mql.yaml
@@ -26,7 +26,7 @@ packs:
 
         Our goal is to build policies that are simple to deploy, accurate, and actionable. 
         
-        If you have any suggestions on improving this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
+        If you have any suggestions for improving this policy, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     filters:
       - asset.platform == "vmware-esxi"
     queries:

--- a/core/mondoo-vmware-incident-response.mql.yaml
+++ b/core/mondoo-vmware-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ## Overview
 
-        VMware vCenter Incident Response Pack by Mondoo is designed to gather data about vCenter and its ESXi hosts.
+        VMware vCenter Incident Response Pack by Mondoo is designed to retrieve data about vCenter and its ESXi hosts.
 
         ### Run query pack
 
@@ -31,13 +31,13 @@ packs:
       - asset.platform == "vmware-esxi"
     queries:
       - uid: mondoo-vmware-incident-response-kernel-modules
-        title: Retrieve list of kernel modules
+        title: Retrieve kernel modules
         query: vsphere.host.kernelModules { * }
       - uid: mondoo-vmware-incident-response-installed-packages
-        title: Retrieve list of installed packages
+        title: Retrieve installed packages
         query: vsphere.host.packages { * } 
       - uid: mondoo-vmware-incident-response-running-services
-        title: Retrieve list of running services
+        title: Retrieve running services
         query: vsphere.host.services.where (running) { * }
         refs:
           - title: VMSA-2021-0002

--- a/core/mondoo-vmware-incident-response.mql.yaml
+++ b/core/mondoo-vmware-incident-response.mql.yaml
@@ -26,7 +26,7 @@ packs:
 
         Our goal is to build policies that are simple to deploy, accurate, and actionable. 
         
-        If you have any suggestions on how to improve this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
+        If you have any suggestions on improving this policy, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     filters:
       - asset.platform == "vmware-esxi"
     queries:

--- a/core/mondoo-windows-incident-response.mql.yaml
+++ b/core/mondoo-windows-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       - asset.platform == "windows"
     queries:
       - uid: mondoo-windows-installed-hotfixes
-        title: Retrieve information about installed hotfixes
+        title: Retrieve installed hotfixes
         query: windows.hotfixes { hotfixId installedOn }
       - uid: mondoo-windows-uptime
         title: Retrieve operating system uptime
@@ -21,5 +21,5 @@ packs:
         title: Retrieve list about installed packages
         query: packages { * }
       - uid: mondoo-windows-running-services
-        title: Retrieve list of running services
+        title: Retrieve running services
         query: services { * }

--- a/core/mondoo-windows-inventory.mql.yaml
+++ b/core/mondoo-windows-inventory.mql.yaml
@@ -10,7 +10,7 @@ packs:
       mondoo.com/category: best-practices
     docs:
       desc: |
-        The Windows Asset Inventory Pack by Mondoo is designed to gather data about Windows hosts for asset inventory. 
+        The Windows Asset Inventory Pack by Mondoo is designed to retrieve data about Windows hosts for asset inventory. 
 
         ## Local scan
         To run this pack locally on a Windows host:
@@ -34,22 +34,22 @@ packs:
       - asset.platform.contains("windows")
     queries:
       - uid: mondoo-windows-asset-info
-        title: Gather asset information
+        title: Retrieve asset information
         query: asset { kind title platform name arch runtime }
       - uid: mondoo-windows-hostname
-        title: Gather the hostname
+        title: Retrieve the hostname
         query: os.hostname
       - uid: mondoo-windows-users 
-        title: Gather regular users 
+        title: Retrieve regular users 
         query: users { * }
       - uid: mondoo-windows-packages
-        title: Gather Windows packages 
+        title: Retrieve Windows packages 
         query: packages {*}
       - uid: mondoo-windows-running-services
-        title: Gather data on running services
+        title: Retrieve data on running services
         query: services.where( running == true ) { * }
       - uid: mondoo-windows-ports-listening
-        title: Gather data on listening ports 
+        title: Retrieve data on listening ports 
         query: ports.listening
       - uid: mondoo-windows-interface-configuration
         title: Retrieve interface configuration of the system

--- a/core/mondoo-windows-inventory.mql.yaml
+++ b/core/mondoo-windows-inventory.mql.yaml
@@ -29,7 +29,7 @@ packs:
         ## Join the community!
         Our goal is to build query packs that are simple to deploy, and provide accurate and useful data. 
         
-        If you have any suggestions on improving this query pack, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
+        If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
     filters:
       - asset.platform.contains("windows")
     queries:

--- a/core/mondoo-windows-inventory.mql.yaml
+++ b/core/mondoo-windows-inventory.mql.yaml
@@ -29,7 +29,7 @@ packs:
         ## Join the community!
         Our goal is to build query packs that are simple to deploy, and provide accurate and useful data. 
         
-        If you have any suggestions on how to improve this query pack, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
+        If you have any suggestions on improving this query pack, or if you need support, [join the community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions. 
     filters:
       - asset.platform.contains("windows")
     queries:
@@ -54,4 +54,3 @@ packs:
       - uid: mondoo-windows-interface-configuration
         title: Retrieve interface configuration of the system
         query: command('wmic nicconfig get macaddress,ipaddress,IPSubnet').stdout
-      

--- a/extra/mondoo-googleworkplace-incident-response.mql.yaml
+++ b/extra/mondoo-googleworkplace-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ### Overview
 
-        The Google Workspace Incident Response query pack gathers configuration data about your Google Workspace investigation during a security incident.
+        The Google Workspace Incident Response query pack retrieves configuration data about your Google Workspace investigation during a security incident.
 
         ### Prerequisites
 

--- a/extra/mondoo-googleworkplace-incident-response.mql.yaml
+++ b/extra/mondoo-googleworkplace-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ### Overview
 
-        The Google Workspace Incident Response query pack retrieves configuration data about your Google Workspace investigation during a security incident.
+        The Google Workspace Incident Response query pack retrieves configuration data about your Google Workspace configuration during a security incident.
 
         ### Prerequisites
 

--- a/extra/mondoo-okta-incident-response.mql.yaml
+++ b/extra/mondoo-okta-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ### Overview
 
-        The Okta Incident Response query pack gathers configuration data about your Okta investigation during a security incident.
+        The Okta Incident Response query pack retrieves configuration data about your Okta investigation during a security incident.
 
         ### Prerequisites
 

--- a/extra/mondoo-okta-incident-response.mql.yaml
+++ b/extra/mondoo-okta-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ### Overview
 
-        The Okta Incident Response query pack retrieves configuration data about your Okta investigation during a security incident.
+        The Okta Incident Response query pack retrieves configuration data about your Okta configuration during a security incident.
 
         ### Prerequisites
 

--- a/extra/mondoo-slack-incident-response.mql.yaml
+++ b/extra/mondoo-slack-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ### Overview
 
-        The Slack Incident Response query pack retrieves configuration data about your Slack investigation during a security incident.
+        The Slack Incident Response query pack retrieves configuration data about your Slack configuration during a security incident.
 
         ### Prerequisites
 

--- a/extra/mondoo-slack-incident-response.mql.yaml
+++ b/extra/mondoo-slack-incident-response.mql.yaml
@@ -12,7 +12,7 @@ packs:
       desc: |
         ### Overview
 
-        The Slack Incident Response query pack gathers configuration data about your Slack investigation during a security incident.
+        The Slack Incident Response query pack retrieves configuration data about your Slack investigation during a security incident.
 
         ### Prerequisites
 


### PR DESCRIPTION
We're all over the place with how we talk about the data we're gathering in cnquery. Most places we say we're "gathering" data so let's use that everywhere. We don't need to say we're gathering a list or gathering information since that's just assumed. Just stick to a consistent and basic form so the output on the CLI looks clean.