### PR TITLE
Gather additional macOS information in the policy

### DIFF
--- a/core/mondoo-aws-inventory.mql.yaml
+++ b/core/mondoo-aws-inventory.mql.yaml
@@ -78,7 +78,7 @@ packs:
       - uid: mondoo-asset-inventory-aws-s3-retrieve-all-data
         title: Retrieve the configuration for all S3 buckets
         mql: aws.s3.buckets
-      - uid: mondoo-asset-inventory-aws-eks-clusterss
+      - uid: mondoo-asset-inventory-aws-eks-clusters
         title: Retrieve the configuration for all AWS EKS clusters
         mql: aws.eks.clusters
       - uid: mondoo-asset-inventory-aws-lambda

--- a/core/mondoo-macos-inventory.mql.yaml
+++ b/core/mondoo-macos-inventory.mql.yaml
@@ -33,15 +33,39 @@ packs:
     filters:
       - asset.platform.contains("macos")
     queries:
+      - uid: mondoo-macos-machine-model
+        title: Retrieve the machine model
+        mql: |
+          parse.json(content: command('system_profiler SPHardwareDataType -json').stdout).params['SPHardwareDataType'].first['machine_model']
+      - uid: mondoo-macos-computer-name
+        title: Retrieve the machine name
+        mql: |
+          parse.json(content: command('system_profiler SPHardwareDataType -json').stdout).params['SPHardwareDataType'].first['machine_name']
+      - uid: mondoo-macos-model-number
+        title: Retrieve the model number
+        mql: |
+          parse.json(content: command('system_profiler SPHardwareDataType -json').stdout).params['SPHardwareDataType'].first['model_number']
+      - uid: mondoo-macos-serial-number
+        title: Retrieve the system serial number
+        mql: |
+          parse.json(content: command('system_profiler SPHardwareDataType -json').stdout).params['SPHardwareDataType'].first['serial_number']
+      - uid: mondoo-macos-cpu-type
+        title: Retrieve the type of CPU
+        mql: |
+          parse.json(content: command('system_profiler SPHardwareDataType -json').stdout).params['SPHardwareDataType'].first['chip_type']
+      - uid: mondoo-macos-physical-memory
+        title: Retrieve the amount of physical memory
+        mql: |
+          parse.json(content: command('system_profiler SPHardwareDataType -json').stdout).params['SPHardwareDataType'].first['physical_memory']
       - uid: mondoo-asset-info
         title: Retrieve asset information
-        mql: asset { kind title platform name arch runtime }
+        mql: asset { kind title platform name arch runtime version }
       - uid: mondoo-hostname
         title: Retrieve the hostname
         mql: os.hostname
       - uid: mondoo-macos-users 
         title: Retrieve regular users 
-        mql: users.where( name != /^_/ && shell != "/usr/bin/false" )
+        mql: users.where( name != /^_/ && shell != "/usr/bin/false" && name != "root")
       - uid: mondoo-macos-packages
         title: Retrieve macOS packages 
         mql: packages

--- a/core/mondoo-macos-inventory.mql.yaml
+++ b/core/mondoo-macos-inventory.mql.yaml
@@ -33,16 +33,16 @@ packs:
     filters:
       - asset.platform.contains("macos")
     queries:
-      - uid: mondoo-macos-machine-model
-        title: Retrieve the machine model
+      - uid: mondoo-macos-machine-model-identifier
+        title: Retrieve the machine model identifer
         mql: |
           parse.json(content: command('system_profiler SPHardwareDataType -json').stdout).params['SPHardwareDataType'].first['machine_model']
-      - uid: mondoo-macos-computer-name
-        title: Retrieve the machine name
+      - uid: mondoo-macos-machine-model-name
+        title: Retrieve the machine model name
         mql: |
           parse.json(content: command('system_profiler SPHardwareDataType -json').stdout).params['SPHardwareDataType'].first['machine_name']
-      - uid: mondoo-macos-model-number
-        title: Retrieve the model number
+      - uid: mondoo-macos-model-part-number
+        title: Retrieve the model part number
         mql: |
           parse.json(content: command('system_profiler SPHardwareDataType -json').stdout).params['SPHardwareDataType'].first['model_number']
       - uid: mondoo-macos-serial-number

--- a/extra/mondoo-asset-count.mql.yaml
+++ b/extra/mondoo-asset-count.mql.yaml
@@ -27,7 +27,7 @@ packs:
           - uid: mondoo-asset-count-aws-ecs-clusters
           - uid: mondoo-asset-count-aws-ecs-container-instances
           - uid: mondoo-asset-count-aws-ecs-containers
-          - uid: mondoo-asset-count-aws-efs-filesysystems
+          - uid: mondoo-asset-count-aws-efs-filesystems
           - uid: mondoo-asset-count-aws-eks-clusters
           - uid: mondoo-asset-count-aws-elasticache-cache-clusters
           - uid: mondoo-asset-count-aws-elasticache-clusters
@@ -148,7 +148,7 @@ packs:
         mql: aws.ecr.images.length
 
       - uid: mondoo-asset-count-aws-rds-dbclusters
-        title: AWS RDS DB Clusters
+        title: AWS RDS Database Clusters
         mql: aws.rds.dbClusters.length
 
       - uid: mondoo-asset-count-aws-cloudtrails
@@ -156,11 +156,11 @@ packs:
         mql: aws.cloudtrail.trails.length
 
       - uid: mondoo-asset-count-aws-dynamodb-tables
-        title: AWS Dynamo DB Tables
+        title: AWS DynamoDB Tables
         mql: aws.dynamodb.tables.length
 
       - uid: mondoo-asset-count-aws-dynamodb-global-tables
-        title: AWS Dynamo DB Global Tables
+        title: AWS DynamoDB Global Tables
         mql: aws.dynamodb.globalTables.length
 
       - uid: mondoo-asset-count-aws-ecs-clusters
@@ -175,16 +175,16 @@ packs:
         title: AWS ECS Containers
         mql: aws.ecs.containers.length
 
-      - uid: mondoo-asset-count-aws-efs-filesysystems
+      - uid: mondoo-asset-count-aws-efs-filesystems
         title: AWS EFS Filesystems
         mql: aws.efs.filesystems.length
 
       - uid: mondoo-asset-count-aws-elasticache-clusters
-        title: AWS Elasticache Clusters
+        title: AWS ElastiCache Clusters
         mql: aws.elasticache.clusters.length
 
       - uid: mondoo-asset-count-aws-elasticache-cache-clusters
-        title: AWS Elasticache Cache Clusters
+        title: AWS ElastiCache Cache Clusters
         mql: aws.elasticache.cacheClusters.length
 
       - uid: mondoo-asset-count-aws-elb-application
@@ -212,15 +212,15 @@ packs:
         mql: aws.kms.keys.length
 
       - uid: mondoo-asset-count-aws-redshift-clusters
-        title: AWS RedShift Clusters
+        title: AWS Redshift Clusters
         mql: aws.redshift.clusters.length
 
       - uid: mondoo-asset-count-aws-sagemaker-endpoints
-        title: AWS Sagemaker Endpoints
+        title: AWS SageMaker Endpoints
         mql: aws.sagemaker.endpoints.length
 
       - uid: mondoo-asset-count-aws-sagemaker-notebook-instances
-        title: AWS Sagemaker Notebook Instances
+        title: AWS SageMaker Notebook Instances
         mql: aws.sagemaker.notebookInstances.length
 
       - uid: mondoo-asset-count-aws-secrets-manager-secrets


### PR DESCRIPTION
- Exclude root from the query that returns regular users
- Add the platform version to our platform information query
- Gather some hardware information so IT departments can get things like the hardware release and serial number


The new data when run locally:
```
Retrieve regular users:
users.where.list: [
  0: user name="tsmith" uid=501 gid=20
]

Retrieve the amount of physical memory:
parse.json.params[SPHardwareDataType].first[physical_memory]: "16 GB"

Retrieve the hostname:
os.hostname: "Tim-Smith.localdomain"

Retrieve the machine model identifier:
parse.json.params[SPHardwareDataType].first[machine_model]: "MacBookPro18,3"

Retrieve the machine model name:
parse.json.params[SPHardwareDataType].first[machine_name]: "MacBook Pro"

Retrieve the model part number:
parse.json.params[SPHardwareDataType].first[model_number]: "MKGQ3LL/A"

Retrieve the system serial number:
parse.json.params[SPHardwareDataType].first[serial_number]: "GGJXG21234"

Retrieve the type of CPU:
parse.json.params[SPHardwareDataType].first[chip_type]: "Apple M1 Pro"

Summary (1 assets)
==================

Target:     Tim-Smith.localdomain
Datapoints: 13
```