### PR TITLE
Add some data to Linux inventory that would help IT teams

### DIFF
--- a/core/mondoo-linux-inventory.mql.yaml
+++ b/core/mondoo-linux-inventory.mql.yaml
@@ -102,3 +102,23 @@ packs:
           if ( package('openssh-server').installed || package('openssh').installed ) {
             sshd.config.params
           }
+      - uid: mondoo-linux-system-manufacturer
+        title: Retrieve the system manufacturer
+        mql: |
+          machine.baseboard.manufacturer
+      - uid: mondoo-linux-system-product-name
+        title: Retrieve the system product name
+        mql: |
+          machine.baseboard.product
+      - uid: mondoo-linux-cpu-type
+        title: Retrieve the type of CPU
+        mql: |
+          command('cat /proc/cpuinfo | grep "model name" | sort -u | cut -d : -f 2-').stdout.trim
+      - uid: mondoo-linux-root-volume
+        title: Retrieve the size and filesystem type of the root volume
+        mql: |
+          command("df -TH / | grep '/dev' | awk '{ print $3 "+'" "'+" $2 }'").stdout.trim
+      - uid: mondoo-linux-physical-memory
+        title: Retrieve the amount of physical memory
+        mql: |
+          command("free --mega | grep Mem | awk '{ print $2}'").stdout.trim + "M"


### PR DESCRIPTION
Add information about the hardware and system configuration that would be helpful for IT teams taking inventory. This is the same data we will be showing on the asset overview pages for Linux in the near future.

```
Retrieve the size and filesystem type of the root volume:
command.stdout.trim: "56G ext4"

Retrieve the system manufacturer:
machine.baseboard.manufacturer: "ASUSTeK COMPUTER INC."

Retrieve the system product name:
machine.baseboard.product: "H87I-PLUS"

Retrieve the type of CPU:
command.stdout.trim: "Intel(R) Core(TM) i7-4785T CPU @ 2.20GHz"

Retrieve the amount of physical memory:
command.stdout.trim.+: "16636M"
```