### PR TITLE
🐛 Do not assign queries to pack (builtin), use top-level queries instead

### DIFF
--- a/extra/mondoo-asset-count.mql.yaml
+++ b/extra/mondoo-asset-count.mql.yaml
@@ -92,242 +92,242 @@ packs:
         filters: asset.platform == "gitlab-group"
         queries:
           - uid: mondoo-asset-count-gitlab-group-projects
-    queries:
-      - uid: mondoo-asset-count-on-vsphere-cluster-esxi
-        title: Retrieve all ESXi hosts
-        query: |
-          vsphere.datacenters { hosts.length }
+queries:
+  - uid: mondoo-asset-count-on-vsphere-cluster-esxi
+    title: Retrieve all ESXi hosts
+    query: |
+      vsphere.datacenters { hosts.length }
 
-      - uid: mondoo-asset-count-on-vsphere-cluster-vms
-        title: Retrieve all VMs from vSphere cluster
-        query: |
-          vsphere.datacenters { vms.length }
+  - uid: mondoo-asset-count-on-vsphere-cluster-vms
+    title: Retrieve all VMs from vSphere cluster
+    query: |
+     vsphere.datacenters { vms.length }
 
-      - uid: mondoo-asset-count-on-azure
-        title: Azure virtual machine count
-        query: |
-          azure.subscription.compute.vms.length
+  - uid: mondoo-asset-count-on-azure
+    title: Azure virtual machine count
+    query: |
+      azure.subscription.compute.vms.length
 
-      - uid: mondoo-count-users-in-azure
-        title: Azure user count
-        query: |
-          microsoft.users.length
+  - uid: mondoo-count-users-in-azure
+    title: Azure user count
+    query: |
+      microsoft.users.length
 
-      - uid: mondoo-asset-count-aws-account-id
-        title: AWS account ID
-        mql: aws.account.id
+  - uid: mondoo-asset-count-aws-account-id
+    title: AWS account ID
+    mql: aws.account.id
 
-      - uid: mondoo-asset-count-aws-acm-certificates
-        title: AWS ACM Certificates
-        mql: aws.acm.certificates.length
+  - uid: mondoo-asset-count-aws-acm-certificates
+    title: AWS ACM Certificates
+    mql: aws.acm.certificates.length
 
-      - uid: mondoo-asset-count-aws-api-gateways
-        title: AWS API Gateways
-        mql: aws.apigateway.restApis.length
+  - uid: mondoo-asset-count-aws-api-gateways
+    title: AWS API Gateways
+    mql: aws.apigateway.restApis.length
 
-      - uid: mondoo-asset-count-aws-autoscaling-groups
-        title: AWS Autoscaling Groups (not created by Mondoo)
-        mql: aws.autoscaling.groups.where( name != "mondoo-scanning-asg" ).length
+  - uid: mondoo-asset-count-aws-autoscaling-groups
+    title: AWS Autoscaling Groups (not created by Mondoo)
+    mql: aws.autoscaling.groups.where( name != "mondoo-scanning-asg" ).length
 
-      - uid: mondoo-asset-count-aws-iam-users
-        title: AWS IAM users
-        mql: aws.iam.users.length
+  - uid: mondoo-asset-count-aws-iam-users
+    title: AWS IAM users
+    mql: aws.iam.users.length
 
-      - uid: mondoo-asset-count-aws-iam-groups
-        title: AWS IAM groups
-        mql: aws.iam.groups.length
+  - uid: mondoo-asset-count-aws-iam-groups
+    title: AWS IAM groups
+    mql: aws.iam.groups.length
 
-      - uid: mondoo-asset-count-aws-iam-policies
-        title: AWS IAM custom policies
-        mql: |
-          aws_account = aws.account.id
-          aws.iam.policies.where( arn.contains(aws_account)).length
+  - uid: mondoo-asset-count-aws-iam-policies
+    title: AWS IAM custom policies
+    mql: |
+      aws_account = aws.account.id
+      aws.iam.policies.where( arn.contains(aws_account)).length
 
-      - uid: mondoo-asset-count-aws-active-regions
-        title: AWS Regions Active
-        mql: aws.regions.length
+  - uid: mondoo-asset-count-aws-active-regions
+    title: AWS Regions Active
+    mql: aws.regions.length
 
-      - uid: mondoo-asset-count-aws-ec2-instances
-        title: AWS EC2 Instances
-        mql: aws.ec2.instances.length
+  - uid: mondoo-asset-count-aws-ec2-instances
+    title: AWS EC2 Instances
+    mql: aws.ec2.instances.length
 
-      - uid: mondoo-asset-count-aws-s3-buckets
-        title: AWS S3 Buckets
-        mql: aws.s3.buckets.length
+  - uid: mondoo-asset-count-aws-s3-buckets
+    title: AWS S3 Buckets
+    mql: aws.s3.buckets.length
 
-      - uid: mondoo-asset-count-aws-vpcs
-        title: AWS VPCs
-        mql: aws.vpcs.length
+  - uid: mondoo-asset-count-aws-vpcs
+    title: AWS VPCs
+    mql: aws.vpcs.length
 
-      - uid: mondoo-asset-count-aws-security-groups
-        title: AWS Security Groups
-        mql: aws.ec2.securityGroups.length
+  - uid: mondoo-asset-count-aws-security-groups
+    title: AWS Security Groups
+    mql: aws.ec2.securityGroups.length
 
-      - uid: mondoo-asset-count-aws-eks-clusters
-        title: AWS Elastic Kubernetes Clusters (EKS)
-        mql: aws.eks.clusters.length
+  - uid: mondoo-asset-count-aws-eks-clusters
+    title: AWS Elastic Kubernetes Clusters (EKS)
+    mql: aws.eks.clusters.length
 
-      - uid: mondoo-asset-count-aws-private-ecr-container-registries
-        title: AWS Private Elastic Container Registries (ECR)
-        mql: aws.ecr.privateRepositories.length
+  - uid: mondoo-asset-count-aws-private-ecr-container-registries
+    title: AWS Private Elastic Container Registries (ECR)
+    mql: aws.ecr.privateRepositories.length
 
-      - uid: mondoo-asset-count-aws-public-ecr-container-registries
-        title: AWS Public Elastic Container Registries (ECR)
-        mql: aws.ecr.publicRepositories.length
+  - uid: mondoo-asset-count-aws-public-ecr-container-registries
+    title: AWS Public Elastic Container Registries (ECR)
+    mql: aws.ecr.publicRepositories.length
 
-      - uid: mondoo-asset-count-aws-ecr-container-images
-        title: AWS Elastic Container Images (ECR)
-        mql: aws.ecr.images.length
+  - uid: mondoo-asset-count-aws-ecr-container-images
+    title: AWS Elastic Container Images (ECR)
+    mql: aws.ecr.images.length
 
-      - uid: mondoo-asset-count-aws-rds-dbclusters
-        title: AWS RDS Database Clusters
-        mql: aws.rds.dbClusters.length
+  - uid: mondoo-asset-count-aws-rds-dbclusters
+    title: AWS RDS Database Clusters
+    mql: aws.rds.dbClusters.length
 
-      - uid: mondoo-asset-count-aws-cloudtrails
-        title: AWS CloudTrails
-        mql: aws.cloudtrail.trails.length
+  - uid: mondoo-asset-count-aws-cloudtrails
+    title: AWS CloudTrails
+    mql: aws.cloudtrail.trails.length
 
-      - uid: mondoo-asset-count-aws-dynamodb-tables
-        title: AWS DynamoDB Tables
-        mql: aws.dynamodb.tables.length
+  - uid: mondoo-asset-count-aws-dynamodb-tables
+    title: AWS DynamoDB Tables
+    mql: aws.dynamodb.tables.length
 
-      - uid: mondoo-asset-count-aws-dynamodb-global-tables
-        title: AWS DynamoDB Global Tables
-        mql: aws.dynamodb.globalTables.length
+  - uid: mondoo-asset-count-aws-dynamodb-global-tables
+    title: AWS DynamoDB Global Tables
+    mql: aws.dynamodb.globalTables.length
 
-      - uid: mondoo-asset-count-aws-ecs-clusters
-        title: AWS ECS Clusters
-        mql: aws.ecs.clusters.length
+  - uid: mondoo-asset-count-aws-ecs-clusters
+    title: AWS ECS Clusters
+    mql: aws.ecs.clusters.length
 
-      - uid: mondoo-asset-count-aws-ecs-container-instances
-        title: AWS ECS Container Instances
-        mql: aws.ecs.containerInstances.length
+  - uid: mondoo-asset-count-aws-ecs-container-instances
+    title: AWS ECS Container Instances
+    mql: aws.ecs.containerInstances.length
 
-      - uid: mondoo-asset-count-aws-ecs-containers
-        title: AWS ECS Containers
-        mql: aws.ecs.containers.length
+  - uid: mondoo-asset-count-aws-ecs-containers
+    title: AWS ECS Containers
+    mql: aws.ecs.containers.length
 
-      - uid: mondoo-asset-count-aws-efs-filesystems
-        title: AWS EFS Filesystems
-        mql: aws.efs.filesystems.length
+  - uid: mondoo-asset-count-aws-efs-filesystems
+    title: AWS EFS Filesystems
+    mql: aws.efs.filesystems.length
 
-      - uid: mondoo-asset-count-aws-elasticache-clusters
-        title: AWS ElastiCache Clusters
-        mql: aws.elasticache.clusters.length
+  - uid: mondoo-asset-count-aws-elasticache-clusters
+    title: AWS ElastiCache Clusters
+    mql: aws.elasticache.clusters.length
 
-      - uid: mondoo-asset-count-aws-elasticache-cache-clusters
-        title: AWS ElastiCache Cache Clusters
-        mql: aws.elasticache.cacheClusters.length
+  - uid: mondoo-asset-count-aws-elasticache-cache-clusters
+    title: AWS ElastiCache Cache Clusters
+    mql: aws.elasticache.cacheClusters.length
 
-      - uid: mondoo-asset-count-aws-elb-application
-        title: AWS Elastic Application Load Balancers
-        mql: aws.elb.loadBalancers.length
+  - uid: mondoo-asset-count-aws-elb-application
+    title: AWS Elastic Application Load Balancers
+    mql: aws.elb.loadBalancers.length
 
-      - uid: mondoo-asset-count-aws-elb-classic
-        title: AWS Elastic Classic Load Balancers
-        mql: aws.elb.classicLoadBalancers.length
+  - uid: mondoo-asset-count-aws-elb-classic
+    title: AWS Elastic Classic Load Balancers
+    mql: aws.elb.classicLoadBalancers.length
 
-      - uid: mondoo-asset-count-aws-emr-clusters
-        title: AWS Elastic Map Reduce Clusters
-        mql: aws.emr.clusters.length
+  - uid: mondoo-asset-count-aws-emr-clusters
+    title: AWS Elastic Map Reduce Clusters
+    mql: aws.emr.clusters.length
 
-      - uid: mondoo-asset-count-aws-es-domains
-        title: AWS Elasticsearch Service Domain
-        mql: aws.es.domains.length
+  - uid: mondoo-asset-count-aws-es-domains
+    title: AWS Elasticsearch Service Domain
+    mql: aws.es.domains.length
 
-      - uid: mondoo-asset-count-aws-guardduty-detectors
-        title: AWS Guard Duty Detectors
-        mql: aws.guardduty.detectors.length
+  - uid: mondoo-asset-count-aws-guardduty-detectors
+    title: AWS Guard Duty Detectors
+    mql: aws.guardduty.detectors.length
 
-      - uid: mondoo-asset-count-aws-kms-keys
-        title: AWS KMS Keys
-        mql: aws.kms.keys.length
+  - uid: mondoo-asset-count-aws-kms-keys
+    title: AWS KMS Keys
+    mql: aws.kms.keys.length
 
-      - uid: mondoo-asset-count-aws-redshift-clusters
-        title: AWS Redshift Clusters
-        mql: aws.redshift.clusters.length
+  - uid: mondoo-asset-count-aws-redshift-clusters
+    title: AWS Redshift Clusters
+    mql: aws.redshift.clusters.length
 
-      - uid: mondoo-asset-count-aws-sagemaker-endpoints
-        title: AWS SageMaker Endpoints
-        mql: aws.sagemaker.endpoints.length
+  - uid: mondoo-asset-count-aws-sagemaker-endpoints
+    title: AWS SageMaker Endpoints
+    mql: aws.sagemaker.endpoints.length
 
-      - uid: mondoo-asset-count-aws-sagemaker-notebook-instances
-        title: AWS SageMaker Notebook Instances
-        mql: aws.sagemaker.notebookInstances.length
+  - uid: mondoo-asset-count-aws-sagemaker-notebook-instances
+    title: AWS SageMaker Notebook Instances
+    mql: aws.sagemaker.notebookInstances.length
 
-      - uid: mondoo-asset-count-aws-secrets-manager-secrets
-        title: AWS Secrets Manager Secrets
-        mql: aws.secretsmanager.secrets.length
+  - uid: mondoo-asset-count-aws-secrets-manager-secrets
+    title: AWS Secrets Manager Secrets
+    mql: aws.secretsmanager.secrets.length
 
-      - uid: mondoo-asset-count-aws-security-hub
-        title: AWS Security Hub
-        mql: aws.securityhub.hubs.length
+  - uid: mondoo-asset-count-aws-security-hub
+    title: AWS Security Hub
+    mql: aws.securityhub.hubs.length
 
-      - uid: mondoo-asset-count-aws-sns-topics
-        title: AWS SNS Topics
-        mql: aws.sns.topics.length
+  - uid: mondoo-asset-count-aws-sns-topics
+    title: AWS SNS Topics
+    mql: aws.sns.topics.length
 
-      - uid: mondoo-asset-count-in-windows-domain
-        title: Retrieve all computer object from the Windows domain
-        query: |
-          parse.json(content: powershell('$time = (Get-Date).Adddays(-(180));Get-ADComputer -Filter {LastLogonTimeStamp -ge $time} -properties * | select Name,Enabled,OperatingSystem,OperatingSystemVersion,LastLogonDate | ConvertTo-Json').stdout).params
+  - uid: mondoo-asset-count-in-windows-domain
+    title: Retrieve all computer object from the Windows domain
+    query: |
+      parse.json(content: powershell('$time = (Get-Date).Adddays(-(180));Get-ADComputer -Filter {LastLogonTimeStamp -ge $time} -properties * | select Name,Enabled,OperatingSystem,OperatingSystemVersion,LastLogonDate | ConvertTo-Json').stdout).params
 
-      - uid: mondoo-asset-count-gcp-storage-buckets
-        title: GCP Project Storage Buckets
-        query: gcp.project.storage.buckets.length
+  - uid: mondoo-asset-count-gcp-storage-buckets
+    title: GCP Project Storage Buckets
+    query: gcp.project.storage.buckets.length
 
-      - uid: mondoo-asset-count-gcp-compute-instances
-        title: GCP Project Compute Instances
-        query: gcp.project.compute.instances.length
+  - uid: mondoo-asset-count-gcp-compute-instances
+    title: GCP Project Compute Instances
+    query: gcp.project.compute.instances.length
 
-      - uid: mondoo-asset-count-gcp-service-accounts
-        title: GCP Project Service Accounts
-        query: gcp.project.iam.serviceAccounts.length
+  - uid: mondoo-asset-count-gcp-service-accounts
+    title: GCP Project Service Accounts
+    query: gcp.project.iam.serviceAccounts.length
 
-      - uid: mondoo-asset-count-gcp-gke-clusters
-        title: GCP Project GKE Clusters
-        query: gcp.project.gke.clusters.length
+  - uid: mondoo-asset-count-gcp-gke-clusters
+    title: GCP Project GKE Clusters
+    query: gcp.project.gke.clusters.length
 
-      - uid: mondoo-asset-count-gcp-bigquery-datasets
-        title: GCP Project BigQuery Datasets
-        query: gcp.project.bigquery.datasets.length
+  - uid: mondoo-asset-count-gcp-bigquery-datasets
+    title: GCP Project BigQuery Datasets
+    query: gcp.project.bigquery.datasets.length
 
-      - uid: mondoo-asset-count-gcp-cloudfunctions
-        title: GCP Project CloudFunctions
-        query: gcp.project.cloudFunctions.length
+  - uid: mondoo-asset-count-gcp-cloudfunctions
+    title: GCP Project CloudFunctions
+    query: gcp.project.cloudFunctions.length
 
-      - uid: mondoo-asset-count-gcp-cloudrun-jobs
-        title: GCP Project Cloud Run Jobs
-        query: gcp.project.cloudRun.jobs.length
+  - uid: mondoo-asset-count-gcp-cloudrun-jobs
+    title: GCP Project Cloud Run Jobs
+    query: gcp.project.cloudRun.jobs.length
 
-      - uid: mondoo-asset-count-gcp-cloudrun-services
-        title: GCP Project Cloud Run Services
-        query: gcp.project.cloudRun.services.length
+  - uid: mondoo-asset-count-gcp-cloudrun-services
+    title: GCP Project Cloud Run Services
+    query: gcp.project.cloudRun.services.length
 
-      - uid: mondoo-asset-count-gcp-cloudrun-operations
-        title: GCP Project Cloud Run Operations
-        query: gcp.project.cloudRun.operations.length
+  - uid: mondoo-asset-count-gcp-cloudrun-operations
+    title: GCP Project Cloud Run Operations
+    query: gcp.project.cloudRun.operations.length
 
-      - uid: mondoo-asset-count-gcp-dns-managed-zones
-        title: GCP Project DNS Managed Zones
-        query: gcp.project.dns.managedZones.length
+  - uid: mondoo-asset-count-gcp-dns-managed-zones
+    title: GCP Project DNS Managed Zones
+    query: gcp.project.dns.managedZones.length
 
-      - uid: mondoo-asset-count-gcp-iam-policies
-        title: GCP Project IAM Policies
-        query: gcp.project.iamPolicy.length
+  - uid: mondoo-asset-count-gcp-iam-policies
+    title: GCP Project IAM Policies
+    query: gcp.project.iamPolicy.length
 
-      - uid: mondoo-asset-count-gcp-kms-keyrings
-        title: GCP Project KMS Keyrings
-        query: gcp.project.kms.keyrings.length
+  - uid: mondoo-asset-count-gcp-kms-keyrings
+    title: GCP Project KMS Keyrings
+    query: gcp.project.kms.keyrings.length
 
-      - uid: mondoo-asset-count-gcp-sql-instances
-        title: GCP Project SQL Instances
-        query: gcp.project.sql.instances.length
+  - uid: mondoo-asset-count-gcp-sql-instances
+    title: GCP Project SQL Instances
+    query: gcp.project.sql.instances.length
 
-      - uid: mondoo-asset-count-gcp-services
-        title: GCP Project Services Enabled
-        query: gcp.project.services.where( enabled ).length
+  - uid: mondoo-asset-count-gcp-services
+    title: GCP Project Services Enabled
+    query: gcp.project.services.where( enabled ).length
 
-      - uid: mondoo-asset-count-gitlab-group-projects
-        title: GitLab Group Projects
-        query: gitlab.group.projects.length
+  - uid: mondoo-asset-count-gitlab-group-projects
+    title: GitLab Group Projects
+    query: gitlab.group.projects.length


### PR DESCRIPTION
Those queries were on the pack level and that pack had no filters, meaning all queries get executed. To fix this, I have moved the queries to the top-level `queries` object which will lead to those queries properly being filtered out