### PR TITLE
Fix OS pack filters to not include host

### DIFF
--- a/core/mondoo-linux-incident-response.mql.yaml
+++ b/core/mondoo-linux-incident-response.mql.yaml
@@ -10,7 +10,7 @@ packs:
       - name: Mondoo, Inc
         email: hello@mondoo.com
     tags:
-      mondoo.com/platform: linux,host
+      mondoo.com/platform: linux
       mondoo.com/category: security
     filters:
       - asset.family.contains("linux")

--- a/core/mondoo-linux-inventory.mql.yaml
+++ b/core/mondoo-linux-inventory.mql.yaml
@@ -10,7 +10,7 @@ packs:
       - name: Mondoo, Inc
         email: hello@mondoo.com
     tags:
-      mondoo.com/platform: linux,host
+      mondoo.com/platform: linux
       mondoo.com/category: best-practices
     docs:
       desc: |

--- a/core/mondoo-macos-incident-response.mql.yaml
+++ b/core/mondoo-macos-incident-response.mql.yaml
@@ -10,7 +10,7 @@ packs:
       - name: Mondoo, Inc
         email: hello@mondoo.com
     tags:
-      mondoo.com/platform: macos,host
+      mondoo.com/platform: macos
       mondoo.com/category: security
     filters:
       - asset.platform == "macos"

--- a/core/mondoo-macos-inventory.mql.yaml
+++ b/core/mondoo-macos-inventory.mql.yaml
@@ -10,7 +10,7 @@ packs:
       - name: Mondoo, Inc
         email: hello@mondoo.com
     tags:
-      mondoo.com/platform: macos,host
+      mondoo.com/platform: macos
       mondoo.com/category: best-practices
     docs:
       desc: |

--- a/core/mondoo-openssl-incident-response.mql.yaml
+++ b/core/mondoo-openssl-incident-response.mql.yaml
@@ -10,7 +10,7 @@ packs:
       - name: Mondoo, Inc
         email: hello@mondoo.com
     tags:
-      mondoo.com/platform: linux,host
+      mondoo.com/platform: linux
       mondoo.com/category: security
     filters:
       - asset.family.contains("linux")

--- a/core/mondoo-windows-incident-response.mql.yaml
+++ b/core/mondoo-windows-incident-response.mql.yaml
@@ -10,7 +10,7 @@ packs:
       - name: Mondoo, Inc
         email: hello@mondoo.com
     tags:
-      mondoo.com/platform: windows,host
+      mondoo.com/platform: windows
       mondoo.com/category: security
     filters:
       - asset.platform == "windows"

--- a/core/mondoo-windows-inventory.mql.yaml
+++ b/core/mondoo-windows-inventory.mql.yaml
@@ -10,7 +10,7 @@ packs:
       - name: Mondoo, Inc
         email: hello@mondoo.com
     tags:
-      mondoo.com/platform: windows,host
+      mondoo.com/platform: windows
       mondoo.com/category: best-practices
     docs:
       desc: |


### PR DESCRIPTION
This will allow us to turn on policy recommendations for domain/IP scanning without these policies showing up