### PR TITLE
Explain what a 2FA null for GH means + remove useless data

### DIFF
--- a/core/mondoo-github-incident-response.mql.yaml
+++ b/core/mondoo-github-incident-response.mql.yaml
@@ -49,7 +49,7 @@ packs:
         title: GitHub Organization MFA status
         docs:
           desc: |
-            This query retrieves whether MFA is required for users of the organization. If this value is null the API token used to query the information did not have owner permissions on the organization.
+            This query retrieves whether multi-factor authentication is required for users of the organization. A null value means the API token used to query the information doesn't have sufficient permissions in the organization. The API token must have owner permissions in the organization to access this data.
         mql: |
           github.organization.twoFactorRequirementEnabled
       - uid: mondoo-incident-response-github-org-owners

--- a/core/mondoo-github-incident-response.mql.yaml
+++ b/core/mondoo-github-incident-response.mql.yaml
@@ -49,7 +49,7 @@ packs:
         title: GitHub Organization MFA status
         docs:
           desc: |
-            This query retrieves whether MFA is required for users of the organization.
+            This query retrieves whether MFA is required for users of the organization. If this value is null the API token used to query the information did not have owner permissions on the organization.
         mql: |
           github.organization.twoFactorRequirementEnabled
       - uid: mondoo-incident-response-github-org-owners
@@ -59,7 +59,13 @@ packs:
             This query retrieves all GitHub organization owners.
         mql: |
           github.organization.owners.length
-          github.organization { owners { name email login } }
+          github.organization {
+            owners {
+              name
+              email
+              login
+            }
+          }
       - uid: mondoo-incident-response-github-org-members
         title: GitHub Organization Members
         docs:
@@ -67,13 +73,11 @@ packs:
             This query retrieves all of the members of the GitHub organization.
         mql: |
           github.organization.members.length
-          github.organization { 
-            members { 
-              name 
-              company 
-              login 
-              email 
-              id 
+          github.organization {
+            members {
+              name
+              login
+              email
             }
           }
       - uid: mondoo-incident-response-github-org-teams
@@ -82,16 +86,15 @@ packs:
           desc: |
             This query retrieves all GitHub organization teams.
         mql: |
-          github.organization { 
-            teams { 
-              slug 
-              privacy 
-              defaultPermission 
-              members { 
-                login 
-                email 
-                company 
-                name 
+          github.organization {
+            teams {
+              slug
+              privacy
+              defaultPermission
+              members {
+                login
+                email
+                name
               }
             }
           }
@@ -102,11 +105,11 @@ packs:
             This query retrieves all of the public repositories within the GitHub organization. The query returns the repo's name and whether the default branch is [protected](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) using protection rules.
         mql: |
           github.organization.repositories.
-            where( private == false ) { 
-              name 
+            where( private == false ) {
+              name
               branches.
-                where( isDefault ) { 
-                  protected 
+                where( isDefault ) {
+                  protected
                 }
             }
       - uid: mondoo-incident-response-github-packages
@@ -115,13 +118,13 @@ packs:
           desc: |
             This query retrieves the packages published to GHCR.io.
         mql: |
-          github.organization { 
-            packages { 
-              name 
-              visibility 
-              packageType 
-              owner { 
-                name 
+          github.organization {
+            packages {
+              name
+              visibility
+              packageType
+              owner {
+                name
               }
             }
           }


### PR DESCRIPTION
Company is a self set field so this is pretty useless for an incident. Also the user ID is a github internal number. Login is what you really want and we already show that.