### PR TITLE
Fix queries that fail to run on MS365

### DIFF
--- a/extra/mondoo-asset-count.mql.yaml
+++ b/extra/mondoo-asset-count.mql.yaml
@@ -17,11 +17,14 @@ packs:
         queries:
           - uid: mondoo-asset-count-on-vsphere-cluster-esxi
           - uid: mondoo-asset-count-on-vsphere-cluster-vms
+      - title: Microsoft 365 asset counts
+        filters: asset.platform == 'microsoft365'
+        queries:
+          - uid: mondoo-count-users-in-entra-id
       - title: Azure asset counts
-        filters: asset.platform == 'azure' || asset.platform == 'microsoft365'
+        filters: asset.platform == 'azure'
         queries:
           - uid: mondoo-asset-count-on-azure
-          - uid: mondoo-count-users-in-azure
       - title: Windows Active Directory asset counts
         filters: asset.platform == "windows"
         queries:
@@ -108,8 +111,8 @@ queries:
     mql: |
       azure.subscription.compute.vms.length
 
-  - uid: mondoo-count-users-in-azure
-    title: Azure user count
+  - uid: mondoo-count-users-in-entra-id
+    title: Entra ID user count
     mql: |
       microsoft.users.length
 


### PR DESCRIPTION
We can't query VM counts on MS365. We need to break this into 2 groups. Also the title of users in Azure doesn't make sense. It's Entra ID

Fixes this failure on MS365 assets:

![image](https://github.com/mondoohq/cnquery-packs/assets/1015200/444bb98a-da3d-4adb-9978-03649ab67bdb)
