### PR TITLE
Adds recommended software updates on macOS

### DIFF
--- a/core/mondoo-macos-inventory.mql.yaml
+++ b/core/mondoo-macos-inventory.mql.yaml
@@ -35,7 +35,7 @@ packs:
 
         If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     filters:
-      - asset.platform.contains("macos")
+      - asset.platform == "macos"
     queries:
       - uid: mondoo-macos-machine-model-identifier
         title: Machine model identifier
@@ -82,3 +82,6 @@ packs:
       - uid: mondoo-macos-interface-configuration
         title: Network interface configuration
         mql: command("ifconfig").stdout
+      - uid: mondoo-macos-recommended-software-updates
+        title: Recommended software updates
+        mql: parse.plist('/Library/Preferences/com.apple.SoftwareUpdate.plist').params['RecommendedUpdates'] 

--- a/core/mondoo-windows-inventory.mql.yaml
+++ b/core/mondoo-windows-inventory.mql.yaml
@@ -35,7 +35,7 @@ packs:
 
         If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     filters:
-      - asset.platform.contains("windows")
+      - asset.platform == "windows"
     queries:
       - uid: mondoo-windows-asset-info
         title: Asset information


### PR DESCRIPTION
This PR adds recommended software updates on macOS. It also updates the filters on macOS and Windows to remove the usage of `.contains("<platform>")` per @arlimus 