### PR TITLE
:star: AWS: Add `variant`-queries 

### DIFF
--- a/core/mondoo-aws-incident-response.mql.yaml
+++ b/core/mondoo-aws-incident-response.mql.yaml
@@ -25,184 +25,348 @@ packs:
         ```bash
         cnquery scan aws -f mondoo-aws-incident-response.mql.yaml
         ```
-    filters:
-      - asset.platform == "aws"
-    queries:
-      - uid: mondoo-incident-response-aws-account-id
-        title: AWS account ID
-        mql: |
-          aws.account.id
-      - uid: mondoo-incident-response-aws-enabled-regions
-        title: All regions enabled in the AWS account
-        docs:
-          desc: |
-            This query retrieves all AWS regions enabled in the account
-        mql: aws { regions }
-      - uid: mondoo-incident-response-aws-user-info
-        title: IAM users with console access
-        docs:
-          desc: |
-            This query retrieves data for users with console access. The following fields are retrieved:
+    groups:
+      - uid: mondoo-incident-response-aws-group
+        title: AWS Asset Inventory Pack Group
+        filters: |
+          asset.runtime == "aws"
+        queries:
+          - uid: mondoo-incident-response-aws-account-id
+          - uid: mondoo-incident-response-aws-enabled-regions
+          - uid: mondoo-incident-response-aws-user-info
+          - uid: mondoo-incident-response-aws-iam-users-multiple-keys
+          - uid: mondoo-incident-response-aws-iam-administrator-access
+          - uid: mondoo-incident-response-aws-iam-full-access
+          - uid: mondoo-incident-response-aws-ec2-instances-public-ip
+          - uid: mondoo-incident-response-aws-ec2-instances-without-tags
+          - uid: mondoo-incident-response-aws-s3-buckets-public
 
-            ```
-            properties['user'] 
-            passwordLastUsed 
-            passwordLastChanged 
-            mfaActive
-            ```
-        mql: |
-          aws.iam.credentialReport.
-            where( passwordEnabled == true ) { 
-              properties['user'] 
-              passwordLastUsed 
-              passwordLastChanged 
-              mfaActive 
-            }
-      - uid: mondoo-incident-response-aws-iam-users-multiple-keys
-        title: IAM users with API access
-        docs:
-          desc: |
-            This query retrieves all of the IAM users that have API access along with the following fields:
 
-            ```
-            properties['user']
-            accessKey1Active
-            accessKey1LastUsedDate
-            accessKey1LastUsedService
-            accessKey1LastRotated
-            accessKey2Active
-            accessKey2LastUsedDate
-            accessKey2LastUsedService
-            accessKey2LastRotated            
-            ```
-        mql: |
-          aws.iam.credentialReport.
-            where( accessKey1Active || accessKey2Active ) { 
-              properties['user']
-              accessKey1Active
-              accessKey1LastUsedDate
-              accessKey1LastUsedService
-              accessKey1LastRotated
-              accessKey2Active
-              accessKey2LastUsedDate
-              accessKey2LastUsedService
-              accessKey2LastRotated
-            }
-      - uid: mondoo-incident-response-aws-iam-administrator-access
-        title: IAM users, groups, and roles to which the AdministratorAccess policy is attached
-        docs:
-          desc: |
-            This query retrieves all IAM users, groups, and roles with the `AdministratorAccess` role attached.
-        mql: |
-          aws.iam.attachedPolicies.
-            where( arn == "arn:aws:iam::aws:policy/AdministratorAccess" ) { 
-              attachedUsers 
-              attachedGroups 
-              attachedRoles 
-            }
-      - uid: mondoo-incident-response-aws-iam-full-access
-        title: IAM users, groups, and roles to which any 'FullAccess' policy is attached
-        docs:
-          desc: |
-            This query retrieves all IAM users, groups, and roles with an AWS FullAccess role attached.
-        mql: |
-          aws.iam.policies.
-            where( name == /FullAccess/i && attachmentCount != 0) { 
-              name
-              createDate
-              updateDate 
-              attachedUsers 
-              attachedGroups 
-              attachedRoles 
-            }
 
-      - uid: mondoo-incident-response-aws-ec2-instances-public-ip
-        title: EC2 instances that have a public IP address
-        docs:
-          desc: |
-            This query retrieves all EC2 instances that have a public IP address attached along with the following fields:
 
-            ```
-            arn 
-            instanceId 
-            region 
-            state
-            vpc.id
-            keypair { 
-              name
-            }
-            securityGroups { 
-              name
-              description
-              ipPermissions
-            }
-            tags
-            ```
-        mql: |
-          aws.ec2.instances.
-            where( publicIp != '' ) { 
-              arn 
-              instanceId 
-              region 
-              state
-              vpc.id
-              keypair { 
-                name
-              }
-              securityGroups { 
-                name
-                description
-                ipPermissions
-              }
-              tags
-            }
-      - uid: mondoo-incident-response-aws-ec2-instances-without-tags
-        title: EC2 instances that do not have tags configured
-        docs:
-          desc: |
-            This query retrieves all EC2 instances that do not have tags configured, along with the following fields:
 
-            ```mql
-            instanceId 
-            region
-            keypair { name }
-            image.name
-            image.id
-            state 
-            ```
-        mql: |
-          aws.ec2.instances.
-            where( tags.length == 0 ) { 
-              instanceId 
-              region
-              keypair { name }
-              image.name
-              image.id
-              state
-            }
-      - uid: mondoo-incident-response-aws-s3-buckets-public
-        title: S3 buckets that are public
-        docs:
-          desc: |
-            This query retrieves all S3 buckets that are configured with public access and returns the following fields:
+queries:
+  - uid: mondoo-incident-response-aws-account-id
+    title: AWS account ID
+    filters: |
+      asset.platform == "aws"
+    mql: |
+      aws.account.id
 
-            ```mql
-            arn
+
+
+  - uid: mondoo-incident-response-aws-enabled-regions
+    title: All regions enabled in the AWS account
+    filters: |
+      asset.platform == "aws"
+    docs:
+      desc: |
+        This query retrieves all AWS regions enabled in the account
+    mql: |
+      aws { regions }
+
+
+
+  - uid: mondoo-incident-response-aws-user-info
+    title: IAM users with console access
+    filters: |
+      asset.platform == "aws"
+    docs:
+      desc: |
+        This query retrieves data for users with console access. The following fields are retrieved:
+
+        ```
+        properties['user']
+        passwordLastUsed
+        passwordLastChanged
+        mfaActive
+        ```
+    mql: |
+      aws.iam.credentialReport.
+        where( passwordEnabled == true ) {
+          properties['user']
+          passwordLastUsed
+          passwordLastChanged
+          mfaActive
+        }
+
+
+
+  - uid: mondoo-incident-response-aws-iam-users-multiple-keys
+    title: IAM users with API access
+    filters: |
+      asset.platform == "aws"
+    docs:
+      desc: |
+        This query retrieves all of the IAM users that have API access along with the following fields:
+
+        ```
+        properties['user']
+        accessKey1Active
+        accessKey1LastUsedDate
+        accessKey1LastUsedService
+        accessKey1LastRotated
+        accessKey2Active
+        accessKey2LastUsedDate
+        accessKey2LastUsedService
+        accessKey2LastRotated
+        ```
+    mql: |
+      aws.iam.credentialReport.
+        where( accessKey1Active || accessKey2Active ) {
+          properties['user']
+          accessKey1Active
+          accessKey1LastUsedDate
+          accessKey1LastUsedService
+          accessKey1LastRotated
+          accessKey2Active
+          accessKey2LastUsedDate
+          accessKey2LastUsedService
+          accessKey2LastRotated
+        }
+
+
+
+  - uid: mondoo-incident-response-aws-iam-administrator-access
+    title: IAM users, groups, and roles to which the AdministratorAccess policy is attached
+    docs:
+      desc: |
+        This query retrieves all IAM users, groups, and roles with the `AdministratorAccess` role attached.
+    variants:
+      - uid: mondoo-incident-response-aws-iam-administrator-access-all
+      - uid: mondoo-incident-response-aws-iam-administrator-access-user
+      - uid: mondoo-incident-response-aws-iam-administrator-access-group
+  - uid: mondoo-incident-response-aws-iam-administrator-access-all
+    filters: |
+      asset.platform == "aws"
+    mql: |
+      aws.iam.attachedPolicies.
+        where( arn == "arn:aws:iam::aws:policy/AdministratorAccess" ) {
+          attachedUsers
+          attachedGroups
+          attachedRoles
+        }
+  - uid: mondoo-incident-response-aws-iam-administrator-access-user
+    filters: |
+      asset.platform == "aws-iam-user"
+      aws.iam.attachedPolicies
+        .where(arn == "arn:aws:iam::aws:policy/AdministratorAccess")
+        .any(attachedUsers
+          .contains(
+            arn.in(asset.ids)
+          )
+        )
+    mql: |
+      aws.iam.user {
+        arn
+        name
+        policies
+        id
+        tags
+        attachedPolicies
+        createDate
+        accessKeys
+        loginProfile
+        groups
+      }
+  - uid: mondoo-incident-response-aws-iam-administrator-access-group
+    filters: |
+      asset.platform == "aws-iam-group"
+      aws.iam.attachedPolicies
+        .where(arn == "arn:aws:iam::aws:policy/AdministratorAccess")
+        .any(attachedGroups
+          .contains(
+            arn.in(asset.ids)
+          )
+        )
+    mql: |
+      aws.iam.group {
+        arn
+        name
+        createDate
+        id
+        usernames
+      }
+
+
+
+  - uid: mondoo-incident-response-aws-iam-full-access
+    title: IAM users, groups, and roles to which any 'FullAccess' policy is attached
+    filters: |
+      asset.platform == "aws"
+    docs:
+      desc: |
+        This query retrieves all IAM users, groups, and roles with an AWS FullAccess role attached.
+    mql: |
+      aws.iam.policies.
+        where( name == /FullAccess/i && attachmentCount != 0) {
+          name
+          createDate
+          updateDate
+          attachedUsers
+          attachedGroups
+          attachedRoles
+        }
+
+
+
+  - uid: mondoo-incident-response-aws-ec2-instances-public-ip
+    title: EC2 instances that have a public IP address
+    docs:
+      desc: |
+        This query retrieves all EC2 instances that have a public IP address attached along with the following fields:
+
+        ```
+        arn
+        instanceId
+        region
+        state
+        vpc.id
+        keypair {
+          name
+        }
+        securityGroups {
+          name
+          description
+          ipPermissions
+        }
+        tags
+        ```
+    variants:
+      - uid: mondoo-incident-response-aws-ec2-instances-public-ip-all
+      - uid: mondoo-incident-response-aws-ec2-instances-public-ip-single
+  - uid: mondoo-incident-response-aws-ec2-instances-public-ip-all
+    filters: |
+      asset.platform == "aws"
+    mql: |
+      aws.ec2.instances.
+        where( publicIp != '' ) {
+          arn
+          instanceId
+          region
+          state
+          vpc.id
+          keypair {
             name
-            location
-            publicAccessBlock
-            encryption
-            tags
-            policy
-            ```
-        mql: |
-          aws.s3.buckets.
-            where( public == true ) {
-              arn
-              name
-              location
-              publicAccessBlock
-              encryption
-              tags
-              policy
-            }
+          }
+          securityGroups {
+            name
+            description
+            ipPermissions
+          }
+          tags
+        }
+  - uid: mondoo-incident-response-aws-ec2-instances-public-ip-single
+    filters: |
+      asset.platform == "aws-ec2-instance"
+      aws.ec2.instance.publicIp != empty
+    mql: |
+      aws.ec2.instance {
+          arn
+          instanceId
+          region
+          state
+          vpc.id
+          keypair {
+            name
+          }
+          securityGroups {
+            name
+            description
+            ipPermissions
+          }
+          tags
+        }
+
+
+
+  - uid: mondoo-incident-response-aws-ec2-instances-without-tags
+    title: EC2 instances that do not have tags configured
+    docs:
+      desc: |
+        This query retrieves all EC2 instances that do not have tags configured, along with the following fields:
+        ```mql
+        instanceId
+        region
+        keypair { name }
+        image.name
+        image.id
+        state
+        ```
+    variants:
+      - uid: mondoo-incident-response-aws-ec2-instances-without-tags-all
+      - uid: mondoo-incident-response-aws-ec2-instances-without-tags-single
+  - uid: mondoo-incident-response-aws-ec2-instances-without-tags-all
+    filters: |
+      asset.platform == "aws"
+    mql: |
+      aws.ec2.instances.
+        where( tags.length == 0 ) {
+          instanceId
+          region
+          keypair { name }
+          image.name
+          image.id
+          state
+        }
+  - uid: mondoo-incident-response-aws-ec2-instances-without-tags-single
+    filters: |
+      asset.platform == "aws-ec2-instance"
+      aws.ec2.instance.tags.length == 0
+    mql: |
+      aws.ec2.instance {
+          instanceId
+          region
+          keypair { name }
+          image.name
+          image.id
+          state
+        }
+
+
+
+  - uid: mondoo-incident-response-aws-s3-buckets-public
+    title: S3 buckets that are public
+    docs:
+      desc: |
+        This query retrieves all S3 buckets that are configured with public access and returns the following fields:
+        ```mql
+        arn
+        name
+        location
+        publicAccessBlock
+        encryption
+        tags
+        policy
+        ```
+    variants:
+      - uid: mondoo-incident-response-aws-s3-buckets-public-all
+      - uid: mondoo-incident-response-aws-s3-buckets-public-single
+  - uid: mondoo-incident-response-aws-s3-buckets-public-all
+    filters: |
+      asset.platform == "aws"
+    mql: |
+      aws.s3.buckets.
+        where( public == true ) {
+          arn
+          name
+          location
+          publicAccessBlock
+          encryption
+          tags
+          policy
+        }
+  - uid: mondoo-incident-response-aws-s3-buckets-public-single
+    filters: |
+      asset.platform == "aws-s3-bucket"
+      aws.s3.bucket.public == true
+    mql: |
+      aws.s3.bucket {
+          arn
+          name
+          location
+          publicAccessBlock
+          encryption
+          tags
+          policy
+        }

--- a/core/mondoo-aws-inventory.mql.yaml
+++ b/core/mondoo-aws-inventory.mql.yaml
@@ -198,7 +198,7 @@ queries:
         variants:
           - uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data-all
           - uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data-single
-      - uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data
+      - uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data-all
         filters: |
           asset.platform == "aws"
         mql: |

--- a/core/mondoo-aws-inventory.mql.yaml
+++ b/core/mondoo-aws-inventory.mql.yaml
@@ -15,85 +15,317 @@ packs:
     docs:
       desc: |
         The AWS Asset Inventory Pack retrieves information about AWS accounts for asset inventory.
-    filters:
-      - asset.platform == "aws"
-    queries:
+    groups:
+      - uid: mondoo-asset-inventory-aws-group
+        title: AWS Asset Inventory Pack Group
+        filters: |
+          asset.runtime == "aws"
+        queries:
+          - uid: mondoo-asset-inventory-aws-account-id
+          - uid: mondoo-asset-inventory-aws-enabled-regions
+          - uid: mondoo-asset-inventory-aws-vpcs
+          - uid: mondoo-asset-inventory-aws-iam-users
+          - uid: mondoo-asset-inventory-aws-iam-groups
+          - uid: mondoo-asset-inventory-aws-iam-roles
+          - uid: mondoo-asset-inventory-aws-iam-policies
+          - uid: mondoo-asset-inventory-aws-ec2-security-groups
+          - uid: mondoo-asset-inventory-aws-ec2-volumes
+          - uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data
+          - uid: mondoo-asset-inventory-aws-rds-dbclusters-all-data
+          - uid: mondoo-asset-inventory-aws-rds-dbinstances-all-data
+          - uid: mondoo-asset-inventory-aws-s3-retrieve-all-data
+          - uid: mondoo-asset-inventory-aws-eks-clusters
+          - uid: mondoo-asset-inventory-aws-lambda
+          - uid: mondoo-asset-inventory-aws-access-analyzer
+          - uid: mondoo-asset-inventory-aws-acm-certificates
+          - uid: mondoo-asset-inventory-aws-cloudtrail-trails
+
+queries:
       - uid: mondoo-asset-inventory-aws-account-id
+        filters: |
+          asset.platform == "aws"
         title: AWS account ID
         mql: |
           aws.account.id
+
+
+
       - uid: mondoo-asset-inventory-aws-enabled-regions
         title: Regions enabled in the AWS account
+        filters: |
+          asset.platform == "aws"
         docs:
           desc: |
             This query retrieves all AWS regions enabled in the account
-        mql: aws { regions }
+        mql: |
+          aws { regions }
+
+
+
       - uid: mondoo-asset-inventory-aws-vpcs
         title: VPCs
         docs:
           desc: |
             This query retrieves all of the configuration data for AWS VPCs
-        mql: aws.vpcs
+        variants:
+          - uid: mondoo-asset-inventory-aws-vpcs-all
+          - uid: mondoo-asset-inventory-aws-vpcs-single
+      - uid: mondoo-asset-inventory-aws-vpcs-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.vpcs
+      - uid: mondoo-asset-inventory-aws-vpcs-single
+        filters: |
+          asset.platform == "aws-vpc"
+        mql: |
+          aws.vpc
+
+
+
       - uid: mondoo-asset-inventory-aws-iam-users
         title: IAM users
         docs:
           desc: |
             This query retrieves data for all IAM users
-        mql: aws.iam.users
+        variants:
+          - uid: mondoo-asset-inventory-aws-iam-users-all
+          - uid: mondoo-asset-inventory-aws-iam-users-single
+      - uid: mondoo-asset-inventory-aws-iam-users-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.iam.users
+      - uid: mondoo-asset-inventory-aws-iam-users-single
+        filters: |
+          asset.platform == "aws-iam-user"
+        mql: |
+          aws.iam.user
+
+
+
       - uid: mondoo-asset-inventory-aws-iam-groups
         title: IAM groups
         docs:
           desc: |
             This query retrieves all of the IAM groups.
-        mql: aws.iam.groups
+        variants:
+          - uid: mondoo-asset-inventory-aws-iam-groups-all
+          - uid: mondoo-asset-inventory-aws-iam-groups-single
+      - uid: mondoo-asset-inventory-aws-iam-groups-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.iam.groups
+      - uid: mondoo-asset-inventory-aws-iam-groups-single
+        filters: |
+          asset.platform == "aws-iam-group"
+        mql: |
+          aws.iam.group
+
+
+
       - uid: mondoo-asset-inventory-aws-iam-roles
         title: IAM roles
         docs:
           desc: |
             This query retrieves all IAM Roles
-        mql: aws.iam.roles
+        variants:
+          - uid: mondoo-asset-inventory-aws-iam-roles-all
+      - uid: mondoo-asset-inventory-aws-iam-roles-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.iam.roles
+
+
+
       - uid: mondoo-asset-inventory-aws-iam-policies
         title: Attached IAM policies
+        filters: |
+          asset.platform == "aws"
         docs:
           desc: |
             This query retrieves all IAM policies attached to a user, group, or role.
         mql: aws.iam.policies.where( attachmentCount > 0 )
+
+
+
       - uid: mondoo-asset-inventory-aws-ec2-security-groups
         title: EC2 Security Groups
         docs:
           desc: |
             This query retrieves all AWS EC2 Security Groups
-        mql: aws.ec2.securityGroups
-      - uid: mondoo-asset-inventory-aws-ebs-volumes
+        variants:
+          - uid: mondoo-asset-inventory-aws-ec2-security-groups-all
+          - uid: mondoo-asset-inventory-aws-ec2-security-groups-single
+      - uid: mondoo-asset-inventory-aws-ec2-security-groups-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.ec2.securityGroups
+      - uid: mondoo-asset-inventory-aws-ec2-security-groups-single
+        filters: |
+          asset.platform == "aws-security-group"
+        mql: |
+          aws.ec2.securitygroup
+
+
+
+      - uid: mondoo-asset-inventory-aws-ec2-volumes
         title: EBS volumes
         docs:
           desc: |
             This query retrieves all AWS EBS volumes
-        mql: aws.ec2.volumes
+        variants:
+          - uid: mondoo-asset-inventory-aws-ec2-volumes-all
+          - uid: mondoo-asset-inventory-aws-ec2-volumes-single
+      - uid: mondoo-asset-inventory-aws-ec2-volumes-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.ec2.volumes
+      - uid: mondoo-asset-inventory-aws-ec2-volumes-single
+        filters: |
+          asset.platform == "aws-ebs-volume"
+        mql: |
+          aws.ec2.volume
+
+
+
       - uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data
         title: Running EC2 instances
-        mql: aws.ec2.instances.where( state == "running" )
+        variants:
+          - uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data-all
+          - uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data-single
+      - uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.ec2.instances.where(state != "terminated")
+      - uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data-single
+        filters: |
+          asset.platform == "aws-ec2-instance"
+          aws.ec2.instance.state != "terminated"
+        mql: |
+          aws.ec2.instance
+
+
+
       - uid: mondoo-asset-inventory-aws-rds-dbclusters-all-data
         title: RDS database clusters configuration
-        mql: aws.rds.dbClusters
+        variants:
+          - uid: mondoo-asset-inventory-aws-rds-dbclusters-all-data-all
+      - uid: mondoo-asset-inventory-aws-rds-dbclusters-all-data-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.rds.dbClusters
+
+
+
       - uid: mondoo-asset-inventory-aws-rds-dbinstances-all-data
         title: RDS database instances
-        mql: aws.rds.dbInstances
+        variants:
+          - uid: mondoo-asset-inventory-aws-rds-dbinstances-all-data-all
+          - uid: mondoo-asset-inventory-aws-rds-dbinstances-all-data-single
+      - uid: mondoo-asset-inventory-aws-rds-dbinstances-all-data-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.rds.dbInstances
+      - uid: mondoo-asset-inventory-aws-rds-dbinstances-all-data-single
+        filters: |
+          asset.platform == "aws-rds-dbinstance"
+        mql: |
+          aws.rds.dbinstance
+
+
+
       - uid: mondoo-asset-inventory-aws-s3-retrieve-all-data
         title: S3 buckets
-        mql: aws.s3.buckets
+        variants:
+          - uid: mondoo-asset-inventory-aws-s3-retrieve-all-data-all
+          - uid: mondoo-asset-inventory-aws-s3-retrieve-all-data-single
+      - uid: mondoo-asset-inventory-aws-s3-retrieve-all-data-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.s3.buckets
+      - uid: mondoo-asset-inventory-aws-s3-retrieve-all-data-single
+        filters: |
+          asset.platform == "aws-s3-bucket"
+        mql: |
+          aws.s3.bucket
+
+
+
       - uid: mondoo-asset-inventory-aws-eks-clusters
         title: EKS clusters
-        mql: aws.eks.clusters
+        variants:
+          - uid: mondoo-asset-inventory-aws-eks-clusters-all
+      - uid: mondoo-asset-inventory-aws-eks-clusters-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.eks.clusters
+
+
+
       - uid: mondoo-asset-inventory-aws-lambda
         title: Lambda functions
-        mql: aws.lambda.functions
+        variants:
+          - uid: mondoo-asset-inventory-aws-lambda-all
+          - uid: mondoo-asset-inventory-aws-lambda-single
+      - uid: mondoo-asset-inventory-aws-lambda-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.lambda.functions
+      - uid: mondoo-asset-inventory-aws-lambda-single
+        filters: |
+          asset.platform == "aws-lambda-function"
+        mql: |
+          aws.lambda.function
+
+
+
       - uid: mondoo-asset-inventory-aws-access-analyzer
         title: Access Analyzers
-        mql: aws.accessAnalyzer.analyzers
+        variants:
+          - uid: mondoo-asset-inventory-aws-access-analyzer-all
+      - uid: mondoo-asset-inventory-aws-access-analyzer-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.accessAnalyzer.analyzers
+
+
+
       - uid: mondoo-asset-inventory-aws-acm-certificates
         title: Certificate Manager certificates
-        mql: aws.acm.certificates
+        variants:
+          - uid: mondoo-asset-inventory-aws-acm-certificates-all
+      - uid: mondoo-asset-inventory-aws-acm-certificates-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.acm.certificates
+
+
+
       - uid: mondoo-asset-inventory-aws-cloudtrail-trails
         title: CloudTrail trails
-        mql: aws.cloudtrail.trails
+        variants:
+          - uid: mondoo-asset-inventory-aws-cloudtrail-trails-all
+          - uid: mondoo-asset-inventory-aws-cloudtrail-trails-single
+      - uid: mondoo-asset-inventory-aws-cloudtrail-trails-all
+        filters: |
+          asset.platform == "aws"
+        mql: |
+          aws.cloudtrail.trails
+      - uid: mondoo-asset-inventory-aws-cloudtrail-trails-single
+        filters: |
+          asset.platform == "aws-cloudtrail-trail"
+        mql: |
+          aws.cloudtrail.trail


### PR DESCRIPTION
Add: `variants:`-queries for the following queries:

**`core/mondoo-aws-incident-response.mql.yaml`**
- uid: mondoo-incident-response-aws-s3-buckets-public
- uid: mondoo-incident-response-aws-ec2-instances-public-ip
- uid: mondoo-incident-response-aws-ec2-instances-without-tags
- uid: mondoo-incident-response-aws-iam-administrator-access

**`core/mondoo-aws-inventory.mql.yaml`**
- uid: mondoo-asset-inventory-aws-vpcs
- uid: mondoo-asset-inventory-aws-iam-users
- uid: mondoo-asset-inventory-aws-iam-groups
- uid: mondoo-asset-inventory-aws-iam-roles
- uid: mondoo-asset-inventory-aws-ec2-security-groups
- uid: mondoo-asset-inventory-aws-ec2-volumes
- uid: mondoo-asset-inventory-aws-ec2-retrieve-all-data
- uid: mondoo-asset-inventory-aws-rds-dbclusters-all-data
- uid: mondoo-asset-inventory-aws-rds-dbinstances-all-data
- uid: mondoo-asset-inventory-aws-s3-retrieve-all-data
- uid: mondoo-asset-inventory-aws-lambda
- uid: mondoo-asset-inventory-aws-access-analyzer
- uid: mondoo-asset-inventory-aws-cloudtrail-trails


## Note:
This needs https://github.com/mondoohq/cnquery/issues/3065 to be fixed first.
