### PR TITLE
Fix running services queries to only be running

### DIFF
--- a/core/mondoo-linux-incident-response.mql.yaml
+++ b/core/mondoo-linux-incident-response.mql.yaml
@@ -46,4 +46,4 @@ packs:
         mql: packages { name version arch installed }
       - uid: mondoo-linux-running-services
         title: Running services
-        mql: services { name running enabled masked type }
+        mql: services.where(running == true) { name running enabled masked type }

--- a/core/mondoo-macos-incident-response.mql.yaml
+++ b/core/mondoo-macos-incident-response.mql.yaml
@@ -41,7 +41,7 @@ packs:
         mql: packages
       - uid: mondoo-macos-incident-response-running-services
         title: Running services
-        mql: services
+        mql: services.where(running == true) { name running enabled masked type }
       - uid: mondoo-macos-incident-response-alf-extensions
         title: Exceptions from the Application Layer Firewall
         mql: macos.alf.exceptions

--- a/core/mondoo-windows-incident-response.mql.yaml
+++ b/core/mondoo-windows-incident-response.mql.yaml
@@ -29,4 +29,4 @@ packs:
         mql: windows.computerInfo
       - uid: mondoo-windows-incident-response-running-services
         title: Running services
-        mql: services
+        mql: services.where(running == true)


### PR DESCRIPTION
We have the same titles queries in the asset overview policies. Just copy the MQL bits from those.