### PR TITLE
add query to get the current logged-in user

### DIFF
--- a/core/mondoo-linux-inventory.mql.yaml
+++ b/core/mondoo-linux-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-linux-inventory
     name: Linux Inventory Pack
-    version: 1.6.0
+    version: 1.6.1
     license: BUSL-1.1
     authors:
       - name: Mondoo, Inc
@@ -160,3 +160,6 @@ packs:
           packages.where(name == /xorg|xserver|wayland/i).any(installed)
         mql: |
           command('lsblk').stdout
+      - uid: mondoo-linux-logged-in-users
+        title: Logged-in users
+        mql: command('users').stdout

--- a/core/mondoo-macos-inventory.mql.yaml
+++ b/core/mondoo-macos-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-macos-inventory
     name: macOS Inventory Pack
-    version: 1.4.0
+    version: 1.4.1
     license: BUSL-1.1
     authors:
       - name: Mondoo, Inc
@@ -129,3 +129,6 @@ packs:
         title: Configuration Profile Data
         mql: |
           parse.json(content: command('system_profiler SPConfigurationProfileDataType -json').stdout).params
+      - uid: mondoo-macos-logged-in-users
+        title: Logged-in users
+        mql: command('users').stdout

--- a/core/mondoo-windows-inventory.mql.yaml
+++ b/core/mondoo-windows-inventory.mql.yaml
@@ -4,7 +4,7 @@
 packs:
   - uid: mondoo-windows-asset-inventory
     name: Windows Asset Inventory Pack
-    version: 1.6.0
+    version: 1.6.1
     license: BUSL-1.1
     authors:
       - name: Mondoo, Inc
@@ -133,3 +133,7 @@ packs:
         title: Scheduled tasks
         mql: |
           parse.json(content: powershell("Get-ScheduledTask | ConvertTo-Json").stdout).params
+      - uid: mondoo-windows-logged-in-users
+        title: Logged-in users
+        mql: |
+          parse.json(content: powershell("Get-Process -IncludeUserName explorer | Select-Object Username | ConvertTo-Json").stdout).params


### PR DESCRIPTION
The idea of identifying logged-in users originates from the fact that identifying devices by their names is often challenging.
It would, therefore, be helpful if the current or last logged-in user were displayed when the device dashboard is shown.