### PR TITLE
:star: `variants:` GCP Asset Inventory

### DIFF
--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -153,7 +153,7 @@ packs:
       - uid: mondoo-asset-inventory-gcp-compute-instances-public-all
         filters: asset.platform == "gcp-project"
         mql: |
-          gcp.compute.instance.networkInterfaces.flat['accessConfigs'][0]['name'] == "External NAT"
+          gcp.compute.instance.networkInterfaces[0]['accessConfigs'][0]['name'] == "External NAT"
       - uid: mondoo-asset-inventory-gcp-compute-instances-public-single
         filters: |
           asset.platform == "gcp-compute-instance"
@@ -164,6 +164,7 @@ packs:
 
       - uid: mondoo-asset-inventory-gcp-compute-networks-count
         title: GCP Compute Engine networks count
+        filters: asset.platform == "gcp-project"
         docs:
           desc: |
             This query retrieves a count of GCP Compute Engine networks configured in a GCP project
@@ -176,4 +177,22 @@ packs:
         docs:
           desc: |
             This query retrieves the data for all GCP Compute Engine networks configured in a GCP project.
-        mql: gcp.compute.networks
+        variants:
+          - uid: mondoo-asset-inventory-gcp-compute-networks-data-all
+          - uid: mondoo-asset-inventory-gcp-compute-networks-data-single
+          - uid: mondoo-asset-inventory-gcp-compute-networks-data-subnet
+      - uid: mondoo-asset-inventory-gcp-compute-networks-data-all
+        filters: |
+          asset.platform == "gcp-project"
+        mql: |
+          gcp.compute.networks
+      - uid: mondoo-asset-inventory-gcp-compute-networks-data-single
+        filters: |
+          asset.platform == "gcp-compute-network"
+        mql: |
+          gcp.compute.network
+      - uid: mondoo-asset-inventory-gcp-compute-networks-data-subnet
+        filters: |
+          asset.platform == "gcp-compute-subnetwork"
+        mql: |
+          gcp.compute.subnetwork

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -18,6 +18,9 @@ packs:
     filters:
       - asset.platform == "gcp" || asset.platform == "gcp-project"
     queries:
+
+
+
       - uid: mondoo-asset-inventory-gcp-project-info
         title: GCP Project Information
         mql: |
@@ -28,54 +31,81 @@ packs:
             state
             labels
           }
+
+
+
       - uid: mondoo-asset-inventory-gcp-project-owners
         title: GCP project owners
         docs:
           desc: |
             This query retrieves data for all owners of the GCP project
         mql: gcp.project.iamPolicy.where( role == "roles/owner" )
+
+
+
       - uid: mondoo-asset-inventory-gcp-project-editors
         title: GCP project editors
         docs:
           desc: |
             This query retrieves data for all editors of the GCP project
         mql: gcp.project.iamPolicy.where( role == "roles/editors" )
+
+
+
       - uid: mondoo-asset-inventory-gcp-iam-roles
         title: IAM Policy roles
         docs:
           desc: |
             This query retrieves all roles defined for a GCP project
         mql: gcp.project.iamPolicy { role }
+
+
+
       - uid: mondoo-asset-inventory-gcp-enabled-services
         title: Services enabled in the GCP project
         docs:
           desc: |
             This query retrieves all services enabled in the GCP Project
         mql: gcp.project.services.where( enabled == true )
+
+
+
       - uid: mondoo-asset-inventory-gcp-gke-clusters-count
         title: GKE clusters count
         docs:
           desc: |
             This query retrieves a count of GKE clusters running in a GCP project
         mql: gcp.project.gke.clusters.length
+
+
+
       - uid: mondoo-asset-inventory-gcp-gke-clusters-data
         title: GKE clusters configuration
         docs:
           desc: |
             This query retrieves all of the configuration data for GKE clusters within a project
         mql: gcp.project.gke.clusters
+
+
+
       - uid: mondoo-asset-inventory-gcp-compute-instances-count
         title: GCP compute instances count
         docs:
           desc: |
             This query retrieves a count of running GCP compute instances in a GCP project
         mql: gcp.compute.instances.where( status == "RUNNING" ).length
+
+
+
       - uid: mondoo-asset-inventory-gcp-compute-instances-data
         title: GCP compute instances
         docs:
           desc: |
             This query retrieves the data for all running GCP compute instances in a GCP project
         mql: gcp.compute.instances.where( status == "RUNNING" )
+
+
+
       - uid: mondoo-asset-inventory-gcp-compute-instances-public
         title: GCP Compute Engine instances
         docs:
@@ -83,12 +113,18 @@ packs:
             This query retrieves the data for all GCP Compute Engine instances that have been configured with an external IP address.
         mql: |
           gcp.compute.instances.where( networkInterfaces[0]['accessConfigs'][0]['name'] == "External NAT" )
+
+
+
       - uid: mondoo-asset-inventory-gcp-compute-networks-count
         title: GCP Compute Engine networks count
         docs:
           desc: |
             This query retrieves a count of GCP Compute Engine networks configured in a GCP project
         mql: gcp.compute.networks.length
+
+
+
       - uid: mondoo-asset-inventory-gcp-compute-networks-data
         title: GCP Compute Engine networks
         docs:

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -95,12 +95,20 @@ packs:
 
       - uid: mondoo-asset-inventory-gcp-gke-clusters-data
         title: GKE clusters configuration
-        filters: asset.platform == "gcp-project"
         docs:
           desc: |
             This query retrieves all of the configuration data for GKE clusters within a project
-        mql: gcp.project.gke.clusters
-
+        variants:
+          - uid: mondoo-asset-inventory-gcp-gke-clusters-data-all
+          - uid: mondoo-asset-inventory-gcp-gke-clusters-data-single
+      - uid: mondoo-asset-inventory-gcp-gke-clusters-data-all
+        filters: asset.platform == "gcp-project"
+        mql: |
+          gcp.project.gke.clusters
+      - uid: mondoo-asset-inventory-gcp-gke-clusters-data-single
+        filters: asset.platform == "gcp-gke-cluster"
+        mql: |
+          gcp.project.gke.cluster
 
 
       - uid: mondoo-asset-inventory-gcp-compute-instances-count
@@ -139,8 +147,18 @@ packs:
         docs:
           desc: |
             This query retrieves the data for all GCP Compute Engine instances that have been configured with an external IP address.
+        variants:
+          - uid: mondoo-asset-inventory-gcp-compute-instances-public-all
+          - uid: mondoo-asset-inventory-gcp-compute-instances-public-single
+      - uid: mondoo-asset-inventory-gcp-compute-instances-public-all
+        filters: asset.platform == "gcp-project"
         mql: |
-          gcp.compute.instances.where( networkInterfaces[0]['accessConfigs'][0]['name'] == "External NAT" )
+          gcp.compute.instance.networkInterfaces.flat['accessConfigs'][0]['name'] == "External NAT"
+      - uid: mondoo-asset-inventory-gcp-compute-instances-public-single
+        filters: |
+          asset.platform == "gcp-compute-instance"
+        mql: |
+          gcp.compute.instances.where(networkInterfaces[0]['accessConfigs'][0]['name'] == "External NAT")
 
 
 

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -39,9 +39,6 @@ packs:
 
 
     queries:
-
-
-
       - uid: mondoo-asset-inventory-gcp-project-info
         title: GCP Project Information
         filters: asset.platform == "gcp-project"

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -17,6 +17,27 @@ packs:
         The GCP Asset Inventory by Mondoo query pack retrieves information about GCP projects for asset inventory.
     filters:
       - asset.runtime == "gcp"
+    groups:
+      - uid: mondoo-asset-inventory-gcp-group
+        title: GCP Asset Inventory Pack Group
+        filters: |
+          asset.runtime == "gcp"
+        queries:
+          - uid: mondoo-asset-inventory-gcp-project-info
+          - uid: mondoo-asset-inventory-gcp-project-owners
+          - uid: mondoo-asset-inventory-gcp-project-editors
+          - uid: mondoo-asset-inventory-gcp-iam-roles
+          - uid: mondoo-asset-inventory-gcp-enabled-services
+          - uid: mondoo-asset-inventory-gcp-gke-clusters-count
+          - uid: mondoo-asset-inventory-gcp-gke-clusters-data
+          - uid: mondoo-asset-inventory-gcp-compute-instances-count
+          - uid: mondoo-asset-inventory-gcp-compute-instances-data
+          - uid: mondoo-asset-inventory-gcp-compute-instances-public
+          - uid: mondoo-asset-inventory-gcp-compute-networks-count
+          - uid: mondoo-asset-inventory-gcp-compute-networks-data
+
+
+
     queries:
 
 

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -153,12 +153,13 @@ packs:
       - uid: mondoo-asset-inventory-gcp-compute-instances-public-all
         filters: asset.platform == "gcp-project"
         mql: |
-          gcp.compute.instance.networkInterfaces[0]['accessConfigs'][0]['name'] == "External NAT"
+          gcp.compute.instances.where(networkInterfaces.where(_['accessConfigs'].where(_['name'] == "External NAT")))
       - uid: mondoo-asset-inventory-gcp-compute-instances-public-single
         filters: |
           asset.platform == "gcp-compute-instance"
+          gcp.compute.instance.networkInterfaces.any(_['accessConfigs'].where(_['name'] == "External NAT"))
         mql: |
-          gcp.compute.instances.where(networkInterfaces[0]['accessConfigs'][0]['name'] == "External NAT")
+          gcp.compute.instance
 
 
 

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -15,8 +15,6 @@ packs:
     docs:
       desc: |
         The GCP Asset Inventory by Mondoo query pack retrieves information about GCP projects for asset inventory.
-    filters:
-      - asset.runtime == "gcp"
     groups:
       - uid: mondoo-asset-inventory-gcp-group
         title: GCP Asset Inventory Pack Group
@@ -35,10 +33,7 @@ packs:
           - uid: mondoo-asset-inventory-gcp-compute-instances-public
           - uid: mondoo-asset-inventory-gcp-compute-networks-count
           - uid: mondoo-asset-inventory-gcp-compute-networks-data
-
-
-
-    queries:
+queries:
       - uid: mondoo-asset-inventory-gcp-project-info
         title: GCP Project Information
         filters: asset.platform == "gcp-project"

--- a/core/mondoo-gcp-inventory.mql.yaml
+++ b/core/mondoo-gcp-inventory.mql.yaml
@@ -16,15 +16,16 @@ packs:
       desc: |
         The GCP Asset Inventory by Mondoo query pack retrieves information about GCP projects for asset inventory.
     filters:
-      - asset.platform == "gcp" || asset.platform == "gcp-project"
+      - asset.runtime == "gcp"
     queries:
 
 
 
       - uid: mondoo-asset-inventory-gcp-project-info
         title: GCP Project Information
+        filters: asset.platform == "gcp-project"
         mql: |
-          gcp.project { 
+          gcp.project {
             name
             id
             number
@@ -36,24 +37,35 @@ packs:
 
       - uid: mondoo-asset-inventory-gcp-project-owners
         title: GCP project owners
+        filters: asset.platform == "gcp-project"
         docs:
           desc: |
             This query retrieves data for all owners of the GCP project
-        mql: gcp.project.iamPolicy.where( role == "roles/owner" )
+        mql: |
+          gcp.project.iamPolicy.where( role == "roles/owner" ) {
+            id
+            members
+          }
 
 
 
       - uid: mondoo-asset-inventory-gcp-project-editors
         title: GCP project editors
+        filters: asset.platform == "gcp-project"
         docs:
           desc: |
             This query retrieves data for all editors of the GCP project
-        mql: gcp.project.iamPolicy.where( role == "roles/editors" )
+        mql: |
+          gcp.project.iamPolicy.where( role == "roles/editors" ) {
+            id
+            members
+          }
 
 
 
       - uid: mondoo-asset-inventory-gcp-iam-roles
         title: IAM Policy roles
+        filters: asset.platform == "gcp-project"
         docs:
           desc: |
             This query retrieves all roles defined for a GCP project
@@ -63,6 +75,7 @@ packs:
 
       - uid: mondoo-asset-inventory-gcp-enabled-services
         title: Services enabled in the GCP project
+        filters: asset.platform == "gcp-project"
         docs:
           desc: |
             This query retrieves all services enabled in the GCP Project
@@ -72,6 +85,7 @@ packs:
 
       - uid: mondoo-asset-inventory-gcp-gke-clusters-count
         title: GKE clusters count
+        filters: asset.platform == "gcp-project"
         docs:
           desc: |
             This query retrieves a count of GKE clusters running in a GCP project
@@ -81,6 +95,7 @@ packs:
 
       - uid: mondoo-asset-inventory-gcp-gke-clusters-data
         title: GKE clusters configuration
+        filters: asset.platform == "gcp-project"
         docs:
           desc: |
             This query retrieves all of the configuration data for GKE clusters within a project
@@ -90,6 +105,7 @@ packs:
 
       - uid: mondoo-asset-inventory-gcp-compute-instances-count
         title: GCP compute instances count
+        filters: asset.platform == "gcp-project"
         docs:
           desc: |
             This query retrieves a count of running GCP compute instances in a GCP project
@@ -102,7 +118,19 @@ packs:
         docs:
           desc: |
             This query retrieves the data for all running GCP compute instances in a GCP project
-        mql: gcp.compute.instances.where( status == "RUNNING" )
+        variants:
+          - uid: mondoo-asset-inventory-gcp-compute-instances-data-all
+          - uid: mondoo-asset-inventory-gcp-compute-instances-data-single
+      - uid: mondoo-asset-inventory-gcp-compute-instances-data-all
+        filters: asset.platform == "gcp-project"
+        mql: |
+          gcp.compute.instances.where( status == "RUNNING" )
+      - uid: mondoo-asset-inventory-gcp-compute-instances-data-single
+        filters: |
+          asset.platform == "gcp-compute-instance"
+          gcp.compute.instance.status == "RUNNING"
+        mql: |
+          gcp.compute.instance
 
 
 


### PR DESCRIPTION
Thanks to @preslavgerchev for the explanation here: https://github.com/mondoohq/cnquery/issues/3065

This works as expected now:
![image](https://github.com/mondoohq/cnquery-packs/assets/112621871/8d46d1e9-b266-4120-9389-cf36bcbd0856)

