### PR TITLE
Update query packs to not use deprecated fields

### DIFF
--- a/.github/actions/spelling/line_forbidden.patterns
+++ b/.github/actions/spelling/line_forbidden.patterns
@@ -12,31 +12,31 @@
 #
 
 # s.b. Allow list
-\s[Ww]hitelist\b
-\s[Ww]hitelisting\b
-\s[Ww]hitelisted\b
-\s[Ww]hite list\b
-\s[Ww]hite listing\b
-\s[Ww]hite listed\b
+\b[Ww]hitelist\b
+\b[Ww]hitelisting\b
+\b[Ww]hitelisted\b
+\b[Ww]hite list\b
+\b[Ww]hite listing\b
+\b[Ww]hite listed\b
 
 # s.b. Block list
-\s[Bb]lacklist\b
-\s[Bb]lacklisting\b
-\s[Bb]lacklisted\b
-\s[Bb]lack list\b
-\s[Bb]lack listing\b
-\s[Bb]lack listed\b
+\b[Bb]lacklist\b
+\b[Bb]lacklisting\b
+\b[Bb]lacklisted\b
+\b[Bb]lack list\b
+\b[Bb]lack listing\b
+\b[Bb]lack listed\b
 
 #
 # Our Terms
 #
 
 # s.b. Mondoo Platform
-\sthe Mondoo Platform\b
-\sMondoo platform\b
+\bthe Mondoo Platform\b
+\bMondoo platform\b
 
 # s.b. Compliance Hub
-\s[Cc]ompliance hub\b
+\b[Cc]ompliance hub\b
 
 #
 # Compliance Terms
@@ -44,6 +44,9 @@
 
 # s.b. SOC 2
 \bSOC2\b
+
+# s.b. NIS2
+\bNIS 2\b
 
 # s.b. ISO 270001
 \bISO270001\b
@@ -65,6 +68,7 @@
 
 # s.b. Docker Hub
 \bDocker[Hh]ub\b
+\bdocker hub\b
 
 # s.b. REST API
 \b[Rr]est API\b
@@ -85,6 +89,9 @@
 #
 # Product Names
 #
+
+# s.b. Memcached
+\bMemCached\b
 
 # s.b. Jira
 \bJIRA\b
@@ -289,6 +296,13 @@
 \bLinked In\b
 \bLinkedin\b
 
+# s.b. Microsoft IIS
+\bIIS Server\b
+
+# s.b. Microsoft SQL Server
+\bSQL server\b
+\bMSSQL\b
+
 #
 # VMware Products
 #
@@ -458,7 +472,7 @@
 \bWorkmail\b
 
 #
-# GCP Products
+# Google Cloud Products
 #
 
 # s.b. AlloyDB
@@ -469,9 +483,11 @@
 
 # s.b. BigLake
 \bBig Lake\b
+\bBiglake\b
 
 # s.b. BigQuery
 \bBig Query\b
+\bBigquery\b
 
 # s.b. Cloud Build
 \bCloudBuild\b
@@ -529,6 +545,16 @@
 # s.b. VMware Engine
 \bVMware engine\b
 \bVMWare Engine\b
+
+# s.b. Bigtable
+\bBigTable\b
+\bBig Table\b
+
+# s.b. Datastore
+\bDataStore\b
+
+# s.b. Memorystore
+\bMemoryStore\b
 
 #
 # Azure Products

--- a/core/mondoo-aws-inventory.mql.yaml
+++ b/core/mondoo-aws-inventory.mql.yaml
@@ -220,7 +220,7 @@ queries:
         filters: |
           asset.platform == "aws"
         mql: |
-          aws.rds.dbClusters
+          aws.rds.clusters
 
 
 
@@ -233,7 +233,7 @@ queries:
         filters: |
           asset.platform == "aws"
         mql: |
-          aws.rds.dbInstances
+          aws.rds.instances
       - uid: mondoo-asset-inventory-aws-rds-dbinstances-all-data-single
         filters: |
           asset.platform == "aws-rds-dbinstance"

--- a/core/mondoo-linux-inventory.mql.yaml
+++ b/core/mondoo-linux-inventory.mql.yaml
@@ -14,7 +14,7 @@ packs:
       mondoo.com/category: best-practices
     docs:
       desc: |
-        The Linux Inventory Pack by Mondoo retrieves data about Linux hosts for asset inventory. 
+        The Linux Inventory Pack by Mondoo retrieves data about Linux hosts for asset inventory.
 
         ## Local scan
         To run this pack locally on a Linux host:
@@ -31,7 +31,7 @@ packs:
         ```
 
         ## Join the community!
-        Our goal is to build query packs that are simple to deploy and provide accurate and useful data. 
+        Our goal is to build query packs that are simple to deploy and provide accurate and useful data.
 
         If you have any suggestions for improving this query pack, or if you need support, [join the Mondoo community](https://github.com/orgs/mondoohq/discussions) in GitHub Discussions.
     filters:
@@ -78,7 +78,7 @@ packs:
       - uid: mondoo-linux-active-connections
         title: Active network connections
         filters: mondoo.capabilities.contains("run-command")
-        query: ports.where(state != "close") { user state port address protocol process remoteAddress remotePort }
+        mql: ports.where(state != "close") { user state port address protocol process remoteAddress remotePort }
       - uid: mondoo-linux-uptime
         title: Operating system uptime
         filters: mondoo.capabilities.contains("run-command")

--- a/core/mondoo-macos-inventory.mql.yaml
+++ b/core/mondoo-macos-inventory.mql.yaml
@@ -99,7 +99,7 @@ packs:
       - uid: mondoo-macos-active-connections
         title: Active network connections
         filters: mondoo.capabilities.contains("run-command")
-        query: ports.where(state != "close") { user state port address protocol process remoteAddress remotePort }
+        mql: ports.where(state != "close") { user state port address protocol process remoteAddress remotePort }
       - uid: mondoo-macos-interface-configuration
         title: Network interface configuration
         filters: mondoo.capabilities.contains("run-command")

--- a/core/mondoo-windows-inventory.mql.yaml
+++ b/core/mondoo-windows-inventory.mql.yaml
@@ -74,7 +74,7 @@ packs:
       - uid: mondoo-windows-active-connections
         title: Active connections of the system
         filters: mondoo.capabilities.contains("run-command")
-        query: ports.where(state != "close") { user state port address protocol process remoteAddress remotePort }
+        mql: ports.where(state != "close") { user state port address protocol process remoteAddress remotePort }
       - uid: mondoo-windows-interface-configuration
         title: Network interfaces
         mql: windows.computerInfo['CsNetworkAdapters']

--- a/extra/mondoo-asset-count.mql.yaml
+++ b/extra/mondoo-asset-count.mql.yaml
@@ -65,7 +65,6 @@ packs:
           - uid: mondoo-asset-count-aws-efs-filesystems
           - uid: mondoo-asset-count-aws-eks-clusters
           - uid: mondoo-asset-count-aws-elasticache-cache-clusters
-          - uid: mondoo-asset-count-aws-elasticache-clusters
           - uid: mondoo-asset-count-aws-elb-application
           - uid: mondoo-asset-count-aws-elb-classic
           - uid: mondoo-asset-count-aws-emr-clusters

--- a/extra/mondoo-asset-count.mql.yaml
+++ b/extra/mondoo-asset-count.mql.yaml
@@ -302,7 +302,7 @@ queries:
 
   - uid: mondoo-asset-count-aws-rds-dbclusters
     title: AWS RDS Database Clusters
-    mql: aws.rds.dbClusters.length
+    mql: aws.rds.clusters.length
 
   - uid: mondoo-asset-count-aws-cloudtrails
     title: AWS CloudTrails
@@ -331,10 +331,6 @@ queries:
   - uid: mondoo-asset-count-aws-efs-filesystems
     title: AWS EFS Filesystems
     mql: aws.efs.filesystems.length
-
-  - uid: mondoo-asset-count-aws-elasticache-clusters
-    title: AWS ElastiCache Clusters
-    mql: aws.elasticache.clusters.length
 
   - uid: mondoo-asset-count-aws-elasticache-cache-clusters
     title: AWS ElastiCache Cache Clusters


### PR DESCRIPTION
- RDS clusters and instances were renamed
- Remove a duplicate ElastiCache query that used the old field